### PR TITLE
Fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam repo add iris-dev https://gitlab.mpi-sws.org/iris/opam.git
 opam pin -n coq 8.11.0
-opam install -j3 coq coq-ext-lib coq-lens coq-iris.3.3.0
+opam install -j3 coq coq-ext-lib coq-lens coq-iris.3.3.0 coq-iris-string-ident
 ```
 
 ### Linux (Ubuntu)

--- a/theories/lang/cpp/logic/simple_pred.v
+++ b/theories/lang/cpp/logic/simple_pred.v
@@ -55,7 +55,7 @@ Proof. by rewrite -pair_op agree_idemp. Qed.
 
 Definition _Z_to_bytes_le {σ:genv} (n : nat) (v : Z) : list N :=
   let p := Z.modulo v (2 ^ Z.of_nat n) in
-  map (fun i : nat => Z.to_N (Z.land 255 (Z.shiftr p (8 * i)))) $ seq 0 n.
+  map (fun i : nat => Z.to_N (Z.land 255 (Z.shiftr p (8 * i)))) $ @seq 0 n.
 
 Definition _Z_to_bytes {σ:genv} (n : nat) (v : Z) : list N :=
   let little := _Z_to_bytes_le (σ:=σ) n v in


### PR DESCRIPTION
I followed README but the build failed, so I made the following fixes.

* added the opam package `coq-idris-string-ident` in README
* added an `@` in front of `seq`

To be honest, I cannot really explain the second change. My brain said
try adding `@` and that fixed the build. Maybe something to do with
implicit arguments.