### PR TITLE
Bump dependencies in opam file

### DIFF
--- a/coq-cpp2v.opam
+++ b/coq-cpp2v.opam
@@ -12,11 +12,11 @@ bug-reports: "https://github.com/bedrocksystems/cpp2v/issues"
 dev-repo: "git+https://github.com/bedrocksystems/cpp2v.git"
 
 depends: [
-  "coq" { = "8.15.1" }
-  "coq-ext-lib" { = "0.11.6" }
-  "coq-iris" {(= "dev.2022-04-12.0.a3bed7ea")}
-  "elpi" {(= "1.15.2")}
-  "coq-elpi" {(= "1.14.0")}
+  "coq" { = "8.16.0" }
+  "coq-ext-lib" { = "0.11.7" }
+  "coq-iris" {(= "dev.2022-11-16.2.da02a192")}
+  "elpi" {(= "1.16.7")}
+  "coq-elpi" {(= "1.16.0")}
 ]
 version: "vdev"
 


### PR DESCRIPTION
Hi, a clean checkout of the repository currently doesn't build (stdpp has moved `numbers.Qp` into a module, amongst other things), so I've updated the dependencies to the latest versions on opam.  This builds and `make test` passes.

(The update to `coq-ext-lib` is not necessary, it builds and passes with the old version as well, but I thought it may be worth doing for consistency.)