### PR TITLE
port to elpi 3.0

### DIFF
--- a/rocq-bluerock-prelude/theories/elpi/derive/bitset.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/bitset.v
@@ -25,7 +25,6 @@ Elpi Db derive.bitset.db lp:{{
   pred finite-type-done o:gref.
   pred bitset-done o:gref.
 }}.
-Elpi Accumulate derive File derive.finite_type.elpi.
 Elpi Accumulate derive lp:{{
   namespace derive.bitset {
     pred mk-simple-bitset i:string, i:gref, i:gref.
@@ -71,7 +70,7 @@ Elpi Accumulate derive lp:{{
 
 #[synterp] Elpi Accumulate derive lp:{{
   namespace derive.bitset {
-    pred main i:string, i:string, i:bool, o:list prop.
+    func main string, string, bool -> list prop.
     main TypeName _ UseToBit CL :- std.do! [
       coq.env.begin-module TypeName none,
       if (UseToBit is tt)
@@ -110,8 +109,8 @@ Elpi Accumulate derive Db derive.bitset.db.
 
 Elpi Accumulate derive lp:{{
   namespace derive.finset {
-    pred main i:gref, i:string, i:bool, o:list prop.
-    main TyGR _Prefix UseToBit Clauses :- std.do! [
+    func main gref, string, bool -> list prop.
+    main TyGR _Prefix UseToBit Clauses :-
       derive-original-gref TyGR OrigGR,
       coq.gref->id TyGR TypeName,
       if (UseToBit is tt)
@@ -119,15 +118,14 @@ Elpi Accumulate derive lp:{{
           derive.bitset.to-bits (global TyGR) ToBit,
           derive.bitset.mk-bitset TypeName TyGR OrigGR ToBit,
         ])
-        (derive.bitset.mk-simple-bitset TypeName TyGR OrigGR),
+        (derive.bitset.mk-simple-bitset TypeName TyGR OrigGR), !,
       Clauses = [bitset-done TyGR],
       std.forall Clauses (x\
         coq.elpi.accumulate _ "derive.bitset.db" (clause _ _ x)
-      ),
-    ].
+      ).
     main _ _ _ _ :- usage.
 
-    pred usage.
+    func usage.
     usage :- coq.error
 "Usage: #[only(bitset)] derive T
 where T is an inductive or a definition that unfolds to an inductive.

--- a/rocq-bluerock-prelude/theories/elpi/derive/common.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/common.v
@@ -19,7 +19,7 @@ Elpi Accumulate derive lp:{{/*(*/
   unfold-constants OrigGR Prefix HasSynterp GR D :-
     P = derive-original-gref GR OrigGR,
     derivation GR Prefix HasSynterp (derive Name Do Done),
-    D = (derive Name (cl\ P => Do cl) (P => Done)).
+    D = (derive Name (cl\ P => Do cl, !) (P => Done)).
   unfold-constants OrigGR Prefix HasSynterp (const C) D :-
     coq.env.const C (some (global C')) _,
     unfold-constants OrigGR Prefix HasSynterp C' D.

--- a/rocq-bluerock-prelude/theories/elpi/derive/countable.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/countable.v
@@ -77,7 +77,7 @@ Elpi File derive.countable.elpi lp:{{
     to-positive CtorList S Ty RTy Match :-
       coq.build-match S Ty (rty RTy) (to-positive-branch CtorList) Match.
 
-    pred mk-countable i:list term, i:string, i:gref, i:gref, o:constant.
+    func mk-countable list term, string, gref, gref -> constant.
     mk-countable Ctors Name VariantGR OrigGR C :- std.do![
       bluerock.elpi-list->list Ctors CtorList,
       std.assert-ok! (coq.elaborate-skeleton CtorList _ ECtorList) "[mk-countable] failed to elaborate ctors",
@@ -112,10 +112,10 @@ Elpi File derive.countable.elpi lp:{{
 Elpi Accumulate derive File derive.countable.elpi.
 Elpi Accumulate derive lp:{{
   namespace derive.countable {
-    pred main i:gref, i:string, o:list prop.
-    main TyGR Prefix Clauses :- std.do! [
+    func main gref, string -> list prop.
+    main TyGR Prefix Clauses :-
       bluerock.get-indt TyGR VariantI,
-      derive-original-gref TyGR OrigGR,
+      derive-original-gref TyGR OrigGR, !,
       coq.env.indt VariantI _ _ _ _ Ctors _,
       std.map Ctors (c\ c'\ c' = global (indc c)) CTerms,
       CountableName is Prefix ^ "countable",
@@ -123,11 +123,10 @@ Elpi Accumulate derive lp:{{
       Clauses = [countable-done TyGR, countable TyGR (const C)],
       std.forall Clauses (x\
         coq.elpi.accumulate _ "derive.stdpp.countable.db" (clause _ _ x)
-      ),
-    ].
+      ).
     main _ _ _ :- usage.
 
-    pred usage.
+    func usage.
     usage :- coq.error
 "Usage: #[only(countable)] derive T
 where T is an inductive or a definition that unfolds to an inductive.

--- a/rocq-bluerock-prelude/theories/elpi/derive/eq_dec.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/eq_dec.v
@@ -44,10 +44,10 @@ Elpi Accumulate derive lp:{{
    * | #[global] Instance C_eq_dec : EqDecision C. Proof. ... Defined.
    */
   namespace derive.eqdec {
-    pred main i:gref, i:string, o:list prop.
-    main TyGR Prefix Clauses :- std.do! [
+    func main gref, string -> list prop.
+    main TyGR Prefix Clauses :-
       InstanceName is Prefix ^ "eq_dec",
-      derive-original-gref TyGR OrigGR,
+      derive-original-gref TyGR OrigGR, !,
       TyEqDecision = {{ EqDecision lp:{{global OrigGR}} }},
       std.assert-ok! (coq.elaborate-skeleton TyEqDecision _ ETyEqDecision) "[derive.eqdec] [TyEqDecision]",
       std.assert-ok! (coq.typecheck {{ lp:BoEqDecision : lp:ETyEqDecision }} _) "typechecking the [EqDecision t] instance failed",
@@ -58,11 +58,10 @@ Elpi Accumulate derive lp:{{
       Clauses = [eqdec-done OrigGR, eqdec OrigGR (const C)],
       std.forall Clauses (x\
         coq.elpi.accumulate _ "derive.stdpp.eq_dec.db" (clause _ _ x)
-      ),
-    ].
+      ).
     main _ _ _ :- usage.
 
-    pred usage.
+    func usage.
     usage :- coq.error
 "Usage: #[only(eq_dec)] derive T
 where T is an inductive or a definition that unfolds to an inductive.

--- a/rocq-bluerock-prelude/theories/elpi/derive/finite.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/finite.v
@@ -86,7 +86,7 @@ Elpi File derive.finite.elpi lp:{{
         mk-finite-constructor Ctor RestValues T CtorsValues
       ].
 
-      pred mk-finite i:string, i:list term, i:gref, i:gref, o:constant.
+      func mk-finite string, list term, gref, gref -> constant.
       mk-finite InstanceName Ctors VariantGR OrigGR C :- std.do![
         VariantTy = global VariantGR,
         OriginalTy = global OrigGR,
@@ -137,10 +137,10 @@ Elpi File derive.finite.elpi lp:{{
 Elpi Accumulate derive File derive.finite.elpi.
 Elpi Accumulate derive lp:{{
   namespace derive.finite {
-    pred main i:gref, i:string, o:list prop.
-    main TyGR Prefix Clauses :- std.do! [
+    func main gref, string -> list prop.
+    main TyGR Prefix Clauses :-
       bluerock.get-indt TyGR VariantI,
-      derive-original-gref TyGR OrigGR,
+      derive-original-gref TyGR OrigGR, !,
       coq.env.indt VariantI _ _ _ _ Ctors _,
       std.map Ctors (c\ c'\ c' = global (indc c)) CTerms,
       FiniteName is Prefix ^ "finite",
@@ -148,11 +148,10 @@ Elpi Accumulate derive lp:{{
       Clauses = [finite-done OrigGR, finite OrigGR (const C)],
       std.forall Clauses (x\
         coq.elpi.accumulate _ "derive.stdpp.finite.db" (clause _ _ x)
-      ),
-    ].
+      ).
     main _ _ _ :- usage.
 
-    pred usage.
+    func usage.
     usage :- coq.error
 "Usage: #[only(finite)] derive T
 where T is an inductive or a definition that unfolds to an inductive.

--- a/rocq-bluerock-prelude/theories/elpi/derive/finite_type.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/finite_type.v
@@ -51,7 +51,7 @@ Elpi File derive.finite_type.elpi lp:{{
       @global! => coq.TC.declare-instance (const Cfin) 0,
     ].
 
-    pred mk-simple-finite i:string, i:gref, i:gref.
+    func mk-simple-finite string, gref, gref.
     mk-simple-finite TypeName TyGR OrigGR :- std.do! [
       mk-finite-prelim TypeName TyGR OrigGR,
       coq.env.include-module-type {coq.locate-module-type "finite_type_mixin"} coq.inline.default,
@@ -90,7 +90,7 @@ Elpi Accumulate derive.finite_type.db File bluerock.typeclass.elpi.
 
 #[synterp] Elpi Accumulate derive lp:{{
   namespace derive.finite_type {
-    pred main i:string, i:string, i:bool, o:list prop.
+    func main string, string, bool -> list prop.
     main TypeName _ UseToN CL :- std.do! [
       coq.env.begin-module TypeName none,
       if (UseToN is tt)
@@ -110,10 +110,10 @@ Elpi Accumulate derive.finite_type.db File bluerock.typeclass.elpi.
 Elpi Accumulate derive Db derive.finite_type.db.
 Elpi Accumulate derive lp:{{
   namespace derive.finite_type {
-    pred main i:gref, i:string, i:bool, o:list prop.
-    main TyGR _Prefix UseToN Clauses :- std.do! [
+    func main gref, string, bool -> list prop.
+    main TyGR _Prefix UseToN Clauses :-
       coq.gref->id TyGR TypeName,
-      derive-original-gref TyGR OrigGR,
+      derive-original-gref TyGR OrigGR, !,
       if (UseToN is tt)
          (std.do! [
            derive.finite_type.to-N (global TyGR) ToN,
@@ -123,11 +123,10 @@ Elpi Accumulate derive lp:{{
       Clauses = [finite-type-done OrigGR],
       std.forall Clauses (x\
         coq.elpi.accumulate _ "derive.finite_type.db" (clause _ _ x)
-      ),
-    ].
+      ).
     main _ _ _ _ :- usage.
 
-    pred usage.
+    func usage.
     usage :- coq.error
 "Usage: #[only(finite_type)] derive T
 where T is an inductive or a definition that unfolds to an inductive.

--- a/rocq-bluerock-prelude/theories/elpi/derive/inhabited.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive/inhabited.v
@@ -34,10 +34,10 @@ Elpi Accumulate derive Db derive.stdpp.inhabited.db.
 
 Elpi Accumulate derive lp:{{
   namespace derive.inhabited {
-    pred main i:gref, i:string, o:list prop.
-    main TyGR Prefix Clauses :- std.do! [
+    func main gref, string -> list prop.
+    main TyGR Prefix Clauses :-
       InstanceName is Prefix ^ "inhabited",
-      derive-original-gref TyGR OrigGR,
+      derive-original-gref TyGR OrigGR, !,
       TyInhabited = {{ Inhabited lp:{{global OrigGR}} }},
       std.assert-ok! (coq.elaborate-skeleton TyInhabited _ ETyInhabited) "[derive.inh.main] [TyInhabited]",
       std.assert-ok! (coq.typecheck {{ lp:BoInhabited : lp:ETyInhabited }} _) "typechecking the [Inhabited t] instance failed",
@@ -48,11 +48,10 @@ Elpi Accumulate derive lp:{{
       Clauses = [inhabited-done OrigGR, inhabited OrigGR (const C)],
       std.forall Clauses (x\
         coq.elpi.accumulate _ "derive.stdpp.inhabited.db" (clause _ _ x)
-      ),
-    ].
+      ).
     main _ _ _ :- usage.
 
-    pred usage.
+    func usage.
     usage :- coq.error
 "Usage: #[only(inhabited)] derive T
 where T is an inductive or a definition that unfolds to an inductive.

--- a/rocq-bluerock-prelude/theories/elpi/derive_test.v
+++ b/rocq-bluerock-prelude/theories/elpi/derive_test.v
@@ -16,7 +16,6 @@ Module Type Alias.
   Module Import Cmd.
     Elpi Command assert_type.
     Elpi Accumulate lp:{{/*(*/
-      pred main i:list argument.
       main [trm (global (const C)), (trm Ty)] :- std.do! [
         coq.env.const C _ CTy,
         Ty = CTy


### PR DESCRIPTION
This is a port to the (upcoming) elpi 3.0. The main difference is that the language feature a static check for determinacy, i.e. code that uses no backtracking. The main change here is that derive wants derivations to be functions (not relations), hence I had to declare them as such.

It uncovered a little bug in Elpi, hopefully I'll manage to integrate this repo in Elpi's CI
https://github.com/LPCIC/elpi/pull/337
