### PR TITLE
Fix Ltac2 Evar.restrict

### DIFF
--- a/ltac2-extra/plugin/misc.ml
+++ b/ltac2-extra/plugin/misc.ml
@@ -458,7 +458,9 @@ let _ =
   define "restrict_evar" (list bool @-> evar @-> tac evar) @@ fun ls e ->
   Proofview.Goal.enter_one @@ fun gl ->
   let sigma = Proofview.Goal.sigma gl in
-  let sigma, e = Evarutil.restrict_evar sigma e (Evd.Filter.make ls) None in
+  let info = Evd.find_undefined sigma e in
+  let filter = Evd.Filter.apply_subfilter (Evd.evar_filter info) ls in
+  let sigma, e = Evarutil.restrict_evar sigma e filter None in
   let open Proofview.Notations in
   Proofview.Unsafe.tclEVARSADVANCE sigma >>= fun _ ->
   Proofview.tclUNIT e

--- a/ltac2-extra/theories/internal/constr.v
+++ b/ltac2-extra/theories/internal/constr.v
@@ -111,7 +111,14 @@ Module Constr.
     Ltac2 @ external is_undefined : evar -> bool :=
       "ltac2_extensions" "evar_is_undefined".
 
-    (** See [Evarutils.restrict_evar] *)
+    (** [restrict] uses [Evarutils.restrict_evar] to restrict the valid
+        hypothesis of an evar.
+        NOTE: Unlike [Evarutils.restrict_evar] and [Evd.restrict], [restrict]
+        expects a filter whose length is equal to __FILTERED__ evar context,
+        i.e. it only filters out hypotheses that were not filtered out before.
+        In other words, the existing filter of the evar is composed with the
+        [bool list] argument provided to [restrict]
+     *)
     Ltac2 @ external restrict : bool list -> evar -> evar :=
       "ltac2_extensions" "restrict_evar".
   End Evar.


### PR DESCRIPTION
The previous code was impossible to use correctly since Ltac2 does not provide access to the current evar filter.

Fixes SkylabsAI/auto#13