### PR TITLE
Revert "Relax the alignment constraint on [operator new]."

### DIFF
--- a/rocq-bluerock-brick/theories/lang/cpp/logic/new_delete.v
+++ b/rocq-bluerock-brick/theories/lang/cpp/logic/new_delete.v
@@ -419,19 +419,6 @@ Module Type Expr__newdelete.
             then [Ecast (Cintegral Talign_val_t) (Eint al Tsize_t)]
             else [].
 
-        (** Only the default allocation functions are required to provide
-            alignment of <<__STDCPP_DEFAULT_NEW_ALIGNMENT__>>.
-            See <https://eel.is/c++draft/cpp.predefined#1.8>.
-         *)
-        Definition requires_default_alignment (tu : translation_unit) (nm : name) : bool :=
-          match nm with
-          | Nglobal (Nop function_qualifiers.N (OONew _) [arg]) =>
-              (* This assumes that names do not use aliases, which they do not *)
-              if bool_decide (arg = Tsize_t) then true
-              else false
-          | _ => false
-          end.
-
         Axiom wp_operand_new :
           forall (oinit : option Expr)
             new_fn (pass_align : bool) new_args aty Q targs
@@ -456,8 +443,8 @@ Module Type Expr__newdelete.
                         <<__STDCPP_DEFAULT_NEW_ALIGNMENT__>> even in cases when the
                         required alignment is actually smaller. When the alignment is
                         smaller, [pass_align] will be [false]. *)
-                    storage_ptr |-> alignedR (if pass_align && ~~requires_default_alignment tu new_fn.1
-                                              then alloc_al else STDCPP_DEFAULT_NEW_ALIGNMENT) **
+                    storage_ptr |-> alignedR (if pass_align then alloc_al
+                                              else STDCPP_DEFAULT_NEW_ALIGNMENT) **
                     storage_ptr |-> blockR alloc_sz 1$m **
                     (Forall (obj_ptr : ptr),
                        provides_storage storage_ptr obj_ptr aty -*
@@ -586,8 +573,7 @@ Module Type Expr__newdelete.
                        else
                          (* [blockR alloc_sz -|- tblockR (Tarray aty array_size)] *)
                          storage_base |-> blockR (overhead_sz + alloc_sz) 1$m **
-                         storage_base |-> alignedR (if pass_align && ~~requires_default_alignment tu new_fn.1
-                                                    then alloc_al else STDCPP_DEFAULT_NEW_ALIGNMENT) **
+                         storage_base |-> alignedR (if pass_align then alloc_al else STDCPP_DEFAULT_NEW_ALIGNMENT) **
                          (Forall (obj_ptr : ptr),
                            storage_base .[Tbyte ! overhead_sz] |-> alignedR alloc_al -*
                            (* This also ensures these pointers share their


### PR DESCRIPTION
Reverts SkylabsAI/BRiCk#45, since it apparently broke the build: https://github.com/SkylabsAI/BRiCk/actions/runs/19389314523.

The failure appears genuine:
```
File "./fmdeps/auto/coq-bluerock-auto-cpp/theories/auto/cpp/hints/new_delete.v", line 401, characters 6-34:
Error: Tactic failure: iFrame: cannot frame
(p |-> alignedR (if pass_align then al else STDCPP_DEFAULT_NEW_ALIGNMENT)).
In nested Ltac calls to "iDestruct (open_constr) as (constr)", 
"_iDestruct0", "iDestructCore (open_constr) as (constr) (tactic3)", 
"tac" (bound to fun H => iDestructHyp H as pat),
"iDestructHyp (constr) as (constr)", "_iDestructHyp0",
"<iris.proofmode.ltac_tactics.iDestructHypFindPat>",
"<iris.proofmode.ltac_tactics.iDestructHypGo>",
"<iris.proofmode.ltac_tactics.iDestructHypGo>",
"<iris.proofmode.ltac_tactics.iDestructHypGo>" and 
"iFrameHyp", last call failed.
```