### PR TITLE
make doc: avoid relative paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ SHELL := /bin/bash
 
 dune_build_folder = ../../_build
 BUILD_ROOT=$(dune_build_folder)/default/fmdeps/BRiCk
-ROCQLIB=$(dune_build_folder)/install/default/lib/coq
+# Beware:
+# 1. ROCQLIB must be absolute
+# 2. dune caching does _not_ track the dependency on ROCQLIB, so CI won't help
+# you if you break rule 1.
+ROCQLIB=${PWD}/$(dune_build_folder)/install/default/lib/coq
 DOC_PATH = rocq-bluerock-brick/doc
 COQDOC_DIR = $(DOC_PATH)/sphinx/_static/coqdoc
 

--- a/rocq-bluerock-brick/doc/sphinx/pointers.rst
+++ b/rocq-bluerock-brick/doc/sphinx/pointers.rst
@@ -122,7 +122,7 @@ object that the pointer refers to; similar concepts are common in modern
 formalizations of pointers, from `CompCert <https://hal.inria.fr/hal-00703441/document>`_ onwards.
 
 Notably, a single call to :cpp:`malloc` might allocate storage for multiple objects:
-each such object will have a distinct allocation ID [#invalid-ptr-no-alloc-id].
+each such object will have a distinct allocation ID\ [#invalid-ptr-no-alloc-id]_.
 
 .. code-block:: coq
 


### PR DESCRIPTION
Fix a regression from https://github.com/SkylabsAI/BRiCk/pull/43.

This _should_ help against errors like

https://github.com/SkylabsAI/auto/actions/runs/19395273848/job/55641090255?pr=24

Please:
- retest that PR over this one.
- if that fixes the error, merge this one.