### PR TITLE
Report dune cram test errors in CI

### DIFF
--- a/rocq-tools/lib/code_quality.mli
+++ b/rocq-tools/lib/code_quality.mli
@@ -57,4 +57,4 @@ type line =
   | Data of string * bool (* Is this the last warning line? *)
 
 val parse_line : string -> line
-val parse_lines : line list -> (int * string) list * Warning.t list * Error.t list
+val parse_lines : ?assume_errors:bool -> line list -> (int * string) list * Warning.t list * Error.t list

--- a/rocq-tools/tests/code-qualityf-diff/cram-tests.t
+++ b/rocq-tools/tests/code-qualityf-diff/cram-tests.t
@@ -1,0 +1,49 @@
+  $ cat > dune-log.json <<EOF
+  > [
+  >   {
+  >     "command": "(cd _build/.sandbox/d408abfb52ef45bc73a852a1f418a0a5/default && /usr/bin/sh -c 'patdiff -keep-whitespace -location-style omake -ascii fmdeps/auto/coq-bluerock-auto-cpp/cram/arith_bug.t/run.t fmdeps/auto/coq-bluerock-auto-cpp/cram/arith_bug.t/run.t.corrected')",
+  >     "output": [
+  >       "------ fmdeps/auto/coq-bluerock-auto-cpp/cram/arith_bug.t/run.t",
+  >       "++++++ fmdeps/auto/coq-bluerock-auto-cpp/cram/arith_bug.t/run.t.corrected",
+  >       "File \"fmdeps/auto/coq-bluerock-auto-cpp/cram/arith_bug.t/run.t\", line 5, characters 0-1:",
+  >       " |  $ DUNE_CACHE=disabled dune build bug.vo 2>&1",
+  >       " |  File \"./bug.v\", line 43, characters 4-37:",
+  >       " |  Error: Timeout!", " |  ",
+  >       "-|  File \"./bug.v\", line 45, characters 4-37:",
+  >       "+|  File \"./bug.v\", line 43, characters 4-37:", " |  Warning:",
+  >       " |  Ill-formed log (Log.collect: span \"arith_solve\" is still open.), using debug mode.",
+  >       " |  [br-ill-formed-log,default]", " |  [1]"
+  >     ],
+  >     "status": 1
+  >   }
+  > ]
+  > EOF
+  $ coqc-perf.code-quality-diff --after-dune dune-log.json
+  # Changes in Warnings or Errors
+  |        |Before|New |Fixed|After|
+  |--------|-----:|---:|----:|----:|
+  |Errors  | 0   | 1 | 0  | 1  |
+  |Warnings| 0   | 0 | 0  | 0  |
+  
+  <details open><summary>
+  
+  ## :x: New Errors (1)
+  
+  </summary>
+  
+  ```
+  File "fmdeps/auto/coq-bluerock-auto-cpp/cram/arith_bug.t/run.t", line 5, characters 0-1:
+   |  $ DUNE_CACHE=disabled dune build bug.vo 2>&1
+   |  File "./bug.v", line 43, characters 4-37:
+   |  Error: Timeout!
+   |  
+  -|  File "./bug.v", line 45, characters 4-37:
+  +|  File "./bug.v", line 43, characters 4-37:
+   |  Warning:
+   |  Ill-formed log (Log.collect: span "arith_solve" is still open.), using debug mode.
+   |  [br-ill-formed-log,default]
+   |  [1]
+  ```
+  
+  </details>
+  


### PR DESCRIPTION
Example output: https://github.com/SkylabsAI/ci/actions/runs/19574000902#summary-56054418985

Soft-depends on https://github.com/SkylabsAI/ci/pull/29 (dune will pick `patdiff` once we have it in the docker image but we might want to hardcode the exact arguments for forwards compatibility)