### PR TITLE
Strengthen monPred_own_weakly_objective

### DIFF
--- a/rocq-skylabs-iris/theories/base_logic/monpred_own.v
+++ b/rocq-skylabs-iris/theories/base_logic/monpred_own.v
@@ -37,7 +37,7 @@ Section with_PROP.
     Next Obligation. solve_proper. Qed.
     Next Obligation. solve_proper. Qed.
     #[local] Definition has_own_monpred_aux : seal (@has_own_monpred_def). Proof. by eexists. Qed.
-    #[global] Instance has_own_monpred : HasOwn monPredI A := has_own_monpred_aux.(unseal).
+    #[local] Instance has_own_monpred : HasOwn monPredI A := has_own_monpred_aux.(unseal).
     Definition has_own_monpred_eq :
       @has_own_monpred = @has_own_monpred_def := has_own_monpred_aux.(seal_eq).
 
@@ -53,7 +53,7 @@ Section with_PROP.
     #[local] Ltac unseal_monpred :=
       constructor; intros; rewrite /own has_own_monpred_eq /has_own_monpred_def.
 
-    #[global] Instance has_own_update_monpred `{!BiBUpd PROP, !HasOwnUpd PROP A} :
+    #[local] Instance has_own_update_monpred `{!BiBUpd PROP, !HasOwnUpd PROP A} :
       HasOwnUpd monPredI A.
     Proof.
       unseal_monpred.
@@ -70,7 +70,7 @@ Section with_PROP.
     Section with_compose_embed_instances.
       Import compose_embed_instances.
 
-      #[global] Instance has_own_valid_monpred
+      #[local] Instance has_own_valid_monpred
         `{!BiEmbed siPropI PROP, !HasOwnValid PROP A} :
         HasOwnValid monPredI A.
       Proof. unseal_monpred. by rewrite own_valid -embedding.embed_embed. Qed.
@@ -81,7 +81,9 @@ Section with_PROP.
     Context {A : ucmra}.
     Context `{Hown: HasOwn PROP A}.
 
-    #[global] Instance has_own_unit_monpred `{!BiBUpd PROP, !HasOwnUnit PROP A}:
+    #[local] Existing Instance has_own_monpred.
+
+    #[local] Instance has_own_unit_monpred `{!BiBUpd PROP, !HasOwnUnit PROP A}:
       HasOwnUnit monPredI A.
     Proof.
       constructor; intros; rewrite /own has_own_monpred_eq /has_own_monpred_def; red.
@@ -89,6 +91,25 @@ Section with_PROP.
     Qed.
   End with_ucmra.
 End with_PROP.
+
+(* These hints are necessary to avoid type class inference loops:
+[has_own_monpred] loops on [HasOwn ?PROP _] by instantiating [PROP := monPred I
+?PROP'] and leaving as obligation [HasOwn ?PROP' _].
+*)
+#[global] Hint Extern 0 (HasOwn ?PROP _) =>
+  assert_fails (is_evar PROP);
+  autoapply @has_own_monpred with typeclass_instances : typeclass_instances.
+
+#[global] Hint Extern 0 (HasOwnUpd ?PROP _) =>
+  assert_fails (is_evar PROP);
+  autoapply @has_own_update_monpred with typeclass_instances : typeclass_instances.
+
+#[global] Hint Extern 0 (HasOwnValid ?PROP _) =>
+  assert_fails (is_evar PROP);
+  autoapply @has_own_valid_monpred with typeclass_instances : typeclass_instances.
+#[global] Hint Extern 0 (HasOwnUnit ?PROP _) =>
+  assert_fails (is_evar PROP);
+  autoapply @has_own_unit_monpred with typeclass_instances : typeclass_instances.
 
 (* Instances for monpred I iPropI *)
 Section si_monpred_embedding.

--- a/rocq-skylabs-iris/theories/base_logic/monpred_own.v
+++ b/rocq-skylabs-iris/theories/base_logic/monpred_own.v
@@ -49,16 +49,14 @@ Section with_has_own.
     HasOwnUpd monPredI A.
   Proof.
     unseal_monpred.
-    - setoid_rewrite <-(@embed_pure PROP).
-      setoid_rewrite <-embed_affinely.
-      setoid_rewrite <-(@embed_sep PROP).
-      setoid_rewrite <-embed_exist.
-      by rewrite -embed_bupd -own_updateP.
-    - setoid_rewrite <-(@embed_pure PROP).
-      setoid_rewrite <-embed_affinely.
-      setoid_rewrite <-(@embed_sep PROP).
-      setoid_rewrite <-embed_exist. rewrite -embed_bupd.
-      by rewrite -own_alloc_strong_dep ?embed_emp.
+    - rewrite own_updateP //.
+      rewrite embed_bupd embed_exist.
+      (do 2 f_equiv) => x.
+      by rewrite embed_sep embed_affinely embed_pure.
+    - rewrite /bi_emp_valid -embed_emp own_alloc_strong_dep //.
+      rewrite embed_bupd embed_exist.
+      (do 2 f_equiv) => x.
+      by rewrite embed_sep embed_affinely embed_pure.
   Qed.
 
   Section with_compose_embed_instances.

--- a/rocq-skylabs-iris/theories/base_logic/monpred_own.v
+++ b/rocq-skylabs-iris/theories/base_logic/monpred_own.v
@@ -15,6 +15,79 @@ Require Import skylabs.iris.extra.bi.own.
 Require Import skylabs.iris.extra.bi.weakly_objective.
 Require Import skylabs.iris.extra.base_logic.iprop_own.
 
+Section with_has_own.
+  Context {I : biIndex} `{Hown: HasOwn PROP A}.
+
+  Notation monPred  := (monPred I PROP).
+  Notation monPredI := (monPredI I PROP).
+
+  (* sealing here should boost performance, but it requires us to re-export
+    properties of embedding. *)
+  Program Definition has_own_monpred_def : HasOwn monPredI A := {|
+    own := λ γ a , ⎡ own γ a ⎤%I |}.
+  Next Obligation. intros. by rewrite -embed_sep -own_op. Qed.
+  Next Obligation. solve_proper. Qed.
+  Next Obligation. solve_proper. Qed.
+  #[local] Definition has_own_monpred_aux : seal (@has_own_monpred_def). Proof. by eexists. Qed.
+  #[global] Instance has_own_monpred : HasOwn monPredI A := has_own_monpred_aux.(unseal).
+  Definition has_own_monpred_eq :
+    @has_own_monpred = @has_own_monpred_def := has_own_monpred_aux.(seal_eq).
+
+  (* some re-exporting of embedding properties *)
+  #[global] Instance monPred_own_objective γ (a : A) :
+    Objective (own γ a).
+  Proof. rewrite has_own_monpred_eq. apply _. Qed.
+
+  #[global] Instance monPred_own_weakly_objective γ x :
+    @WeaklyObjective I PROP (own γ x).
+  Proof. rewrite has_own_monpred_eq. apply _. Qed.
+
+  #[local] Ltac unseal_monpred :=
+    constructor; intros; rewrite /own has_own_monpred_eq /has_own_monpred_def.
+
+  #[global] Instance has_own_update_monpred `{!BiBUpd PROP, !HasOwnUpd PROP A} :
+    HasOwnUpd monPredI A.
+  Proof.
+    unseal_monpred.
+    - setoid_rewrite <-(@embed_pure PROP).
+      setoid_rewrite <-embed_affinely.
+      setoid_rewrite <-(@embed_sep PROP).
+      setoid_rewrite <-embed_exist.
+      by rewrite -embed_bupd -own_updateP.
+    - setoid_rewrite <-(@embed_pure PROP).
+      setoid_rewrite <-embed_affinely.
+      setoid_rewrite <-(@embed_sep PROP).
+      setoid_rewrite <-embed_exist. rewrite -embed_bupd.
+      by rewrite -own_alloc_strong_dep ?embed_emp.
+  Qed.
+
+  Section with_compose_embed_instances.
+    Import compose_embed_instances.
+
+    #[global] Instance has_own_valid_monpred
+      `{!BiEmbed siPropI PROP, !HasOwnValid PROP A} :
+      HasOwnValid monPredI A.
+    Proof. unseal_monpred. by rewrite own_valid -embedding.embed_embed. Qed.
+  End with_compose_embed_instances.
+End with_has_own.
+
+Section with_has_own_unit.
+  Context {A : ucmra}.
+  Context {I : biIndex}.
+  Context `{!BiBUpd PROP}.
+  Context `{Hown: HasOwn PROP A, Hou : !HasOwnUnit PROP A}.
+
+  Notation monPred  := (monPred I PROP).
+  Notation monPredI := (monPredI I PROP).
+
+  #[global] Instance has_own_unit_monpred :
+    HasOwnUnit monPredI A.
+  Proof using Hou.
+    constructor; intros; rewrite /own has_own_monpred_eq /has_own_monpred_def; red.
+    by rewrite -(@embed_emp PROP) -embed_bupd own_unit.
+  Qed.
+End with_has_own_unit.
+
 (* Instances for monpred *)
 
 Section si_monpred_embedding.
@@ -36,61 +109,3 @@ Section si_monpred_embedding.
     ⎡ si_cmra_valid a ⎤ ⊣⊢@{monPredI} ⎡ uPred_cmra_valid a ⎤.
   Proof. by rewrite -si_cmra_valid_validI embedding.embed_embed. Qed.
 End si_monpred_embedding.
-
-Section monpred_instances.
-  Context {I : biIndex} `{Hin: inG Σ A}.
-
-  Notation iPropI   := (iPropI Σ).
-  Notation monPred  := (monPred I iPropI).
-  Notation monPredI := (monPredI I iPropI).
-
-  (* sealing here should boost performance, but it requires us to re-export
-    properties of embedding. *)
-  Program Definition has_own_monpred_def : HasOwn monPredI A := {|
-    own := λ γ a , ⎡ own γ a ⎤%I |}.
-  Next Obligation. intros. by rewrite -embed_sep -own_op. Qed.
-  Next Obligation. solve_proper. Qed.
-  Next Obligation. solve_proper. Qed.
-  #[local] Definition has_own_monpred_aux : seal (@has_own_monpred_def). Proof. by eexists. Qed.
-  #[global] Instance has_own_monpred : HasOwn monPredI A := has_own_monpred_aux.(unseal).
-  Definition has_own_monpred_eq :
-    @has_own_monpred = @has_own_monpred_def := has_own_monpred_aux.(seal_eq).
-
-  #[local] Ltac unseal_monpred :=
-    constructor; intros; rewrite /own has_own_monpred_eq /has_own_monpred_def; red.
-
-  #[global] Instance has_own_valid_monpred: HasOwnValid monPredI A.
-  Proof. unseal_monpred. by rewrite own_valid -embedding.embed_embed. Qed.
-
-  #[global] Instance has_own_update_monpred : HasOwnUpd monPredI A.
-  Proof.
-    unseal_monpred.
-    - setoid_rewrite <-(@embed_pure iPropI).
-      setoid_rewrite <-embed_affinely.
-      setoid_rewrite <-(@embed_sep iPropI).
-      setoid_rewrite <-embed_exist.
-      by rewrite -embed_bupd -own_updateP.
-    - setoid_rewrite <-(@embed_pure iPropI).
-      setoid_rewrite <-embed_affinely.
-      setoid_rewrite <-(@embed_sep iPropI).
-      setoid_rewrite <-embed_exist. rewrite -embed_bupd -(@embed_emp iPropI).
-      by rewrite -own_alloc_strong_dep.
-  Qed.
-
-  (* some re-exporting of embedding properties *)
-  #[global] Instance monPred_own_objective γ (a : A) :
-    Objective (own γ a).
-  Proof. rewrite has_own_monpred_eq. apply _. Qed.
-
-  #[global] Instance monPred_own_weakly_objective γ x :
-    @WeaklyObjective I iPropI (own γ x).
-  Proof. rewrite has_own_monpred_eq. apply _. Qed.
-
-End monpred_instances.
-
-#[global] Instance has_own_unit_monpred {I : biIndex} {Σ} {A : ucmra} `{Hin: inG Σ A} :
-  HasOwnUnit (monPredI I (iPropI Σ)) A.
-Proof.
-  constructor; intros; rewrite /own has_own_monpred_eq /has_own_monpred_def; red.
-  by rewrite -(@embed_emp (iPropI _)) -embed_bupd own_unit.
-Qed.


### PR DESCRIPTION
## Downstream

https://github.com/SkyLabsAI/auto/pull/69
https://github.com/SkyLabsAI/bluerock.NOVA/pull/4
https://github.com/SkyLabsAI/bluerock.bhv/pull/10

## Description

With this MR, proving `WeaklyObjective (own (PROP := mpredI) γ a)` requires just `HasOwn iPropI A` instead of the stronger `inG Σ A`. We follow the plan in #69, and apply it to a few other definitions; discussed with @hans89 .

### Challenge: preserving termination of typeclass inference

Some new recursive instances can cause non-termination.
This MR adds recursive instances `HasOwn PROP A -> HasOwn (monPredI I PROP) A`, and these are unsafe since `HasOwn` lacks a mode: they can cause an infinite loop when applied to `HasOwn ?PROP A` by instantiating `?PROP := monPred ?I ?PROP'`. A `Hint Mode HasOwn + -` would fix this problem but require quite a few annotations. 

Janno suggested turning these instances into `Hint Extern` to perform mode-checking only for these instances.
