### PR TITLE
Add semantics of the [move] builtin.

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/logic/builtins.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/builtins.v
@@ -68,6 +68,9 @@ Section wp_builtin.
   Axiom wp_expect : forall exp c Q,
       Q exp |-- wp_builtin "__builtin_expect" (Tfunction Tlong (Tlong :: Tlong :: nil)) (exp :: c :: nil) Q.
 
+  Axiom wp_move : forall ty arg Q,
+      Q arg |-- wp_builtin "move" (Tfunction (Trv_ref ty) [ty]) (arg :: nil) Q.
+
   (** Bit computations
    *)
 


### PR DESCRIPTION
In some compilers (including Clang), `move` is a builtin.