### PR TITLE
bytestring: add missing instances/settings

### DIFF
--- a/rocq-skylabs-prelude/theories/bytestring.v
+++ b/rocq-skylabs-prelude/theories/bytestring.v
@@ -9,7 +9,8 @@ Require Import stdpp.namespaces.
 Require Import skylabs.prelude.base.
 Require Export skylabs.prelude.bytestring_core.
 
-(** Bytestring extensions. Integrate with stdpp and strings. *)
+(** Bytestring extensions. Integrate with stdpp and strings.
+Caveat: some lemmas here are new, not just lifting of [bytestring_core] properties. *)
 (** bytes *)
 #[global] Instance byte_inhabited : Inhabited Byte.byte := populate Byte.x00.
 #[global] Instance byte_eq_dec : EqDecision Byte.byte := Byte.byte_eq_dec.
@@ -44,6 +45,15 @@ Qed.
 #[global] Instance bytestring_parse_surj : Surj eq BS.parse :=
   cancel_surj.
 
+#[global] Instance bytestring_append_inj_r xs : Inj eq eq (BS.append xs).
+Proof.
+  elim: xs => [|x xs /= IH] ys1 ys2 //; rewrite !BS.append_cons_l.
+  move => [/(inj (BS.append _))] //.
+Qed.
+#[global] Instance bytestring_append_assoc : Assoc eq BS.append.
+Proof.
+  elim => [|x xs IH] ys zs //=; by rewrite !BS.append_cons_l -IH.
+Qed.
 
 (** bytestrings *)
 (** Many functions on byte strings are meant to be always used

--- a/rocq-skylabs-prelude/theories/bytestring.v
+++ b/rocq-skylabs-prelude/theories/bytestring.v
@@ -6,9 +6,8 @@
 Require Import stdpp.countable.
 Require Import stdpp.strings.
 Require Import stdpp.namespaces.
+Require Import skylabs.prelude.base.
 Require Export skylabs.prelude.bytestring_core.
-
-#[local] Set Default Proof Using "Type".
 
 (** Bytestring extensions. Integrate with stdpp and strings. *)
 (** bytes *)
@@ -25,10 +24,10 @@ Defined.
 #[global] Instance bytestring_inhabited : Inhabited bs. Proof. exact (populate ""%bs). Qed.
 
 #[global] Instance byte_to_N_inj : Inj eq eq Byte.to_N.
-Proof. intros ?? E; apply (inj Some). by rewrite <-!Byte.of_to_N, E. Qed.
+Proof. intros ?? E; apply (inj Some). by rewrite -!Byte.of_to_N E. Qed.
 #[global] Instance byte_of_N_surj : Surj eq Byte.of_N.
 Proof.
-  intros [b|]. by rewrite <-!Byte.of_to_N; eauto.
+  intros [b|]. by rewrite -!Byte.of_to_N; eauto.
   exists 256%N. by rewrite Byte.of_N_None_iff.
 Qed.
 
@@ -74,7 +73,7 @@ Module Import BS.
   Proof.
     intros *; induction b as [| a b' IHb']; simpl.
     - by reflexivity.
-    - by rewrite IHb', Ascii.byte_of_ascii_of_byte.
+    - by rewrite IHb' Ascii.byte_of_ascii_of_byte.
   Qed.
 
   Lemma to_string_of_string_inv :
@@ -83,7 +82,7 @@ Module Import BS.
   Proof.
     intros *; induction b as [| a b' IHb']; simpl.
     - by reflexivity.
-    - by rewrite IHb', Ascii.ascii_of_byte_of_ascii.
+    - by rewrite IHb' Ascii.ascii_of_byte_of_ascii.
   Qed.
 
   Definition bytes_to_string (xs : list N) : bs :=
@@ -95,7 +94,7 @@ Module Import BS.
   #[global] Instance bytes_to_string_to_bytes : Cancel eq bytes_to_string string_to_bytes.
   Proof.
     intros bs. unfold bytes_to_string, string_to_bytes; induction bs; csimpl. done.
-    by rewrite IHbs, Byte.of_to_N.
+    by rewrite IHbs Byte.of_to_N.
   Qed.
   (* TODO: [string_to_bytes (bytes_to_string bs) = bs], but it only holds for "valid" [bs]. *)
 

--- a/rocq-skylabs-prelude/theories/bytestring_core.v
+++ b/rocq-skylabs-prelude/theories/bytestring_core.v
@@ -211,6 +211,24 @@ Module Import BS.
   End Bytestring_notations.
   #[local] Notation Byte b := (String b EmptyString) (only parsing).
 
+  (* Block [append] reduction on both arguments being constructors.
+  Otherwise, ["ab" ++ neutral] would simplify to [String 'a' (String 'b'
+  neutral)], which is not what we want in concrete examples.
+
+  Lemmas [append_nil_l] and [append_cons_l] still allow reduction when the left
+  argument is a constructor.
+
+  Example: [Eval cbn in (fun str => "ab" ++ str)%bs].
+  Before [λ str : bs, String "a" (String "b" str)].
+  After: [λ str : bs, ("ab" ++ str)%bs].
+  *)
+  #[global] Arguments append !_ !_ /.
+
+  Lemma append_nil_l ys : (EmptyString ++ ys = ys)%bs.
+  Proof. reflexivity. Qed.
+  Lemma append_cons_l x xs ys : (String x xs ++ ys = String x (xs ++ ys))%bs.
+  Proof. reflexivity. Qed.
+
   Lemma print_rev_append s t :
     print (rev_append s t) = List.rev_append (print s) (print t).
   Proof. by elim: s t; cbn. Qed.


### PR DESCRIPTION
Upstreamed from https://github.com/SkyLabsAI/brick-libcpp/pull/39.

This is a draft to assess the breakage from each of the two commits — I fear restricting reduction might cause regressions.