### PR TITLE
[rocq-perf] check [rocq] exist in the workspace.

### DIFF
--- a/rocq-tools/bin/rocq_perf.ml
+++ b/rocq-tools/bin/rocq_perf.ml
@@ -40,7 +40,9 @@ type files = {
 let rocq_bin =
   match Sys.getenv_opt "DUNE_SOURCEROOT" with
   | None       -> "rocq"
-  | Some(root) -> Filename.concat root "_build/install/default/bin/rocq"
+  | Some(root) ->
+  let rocq_bin = Filename.concat root "_build/install/default/bin/rocq" in
+  if Sys.file_exists rocq_bin then rocq_bin else "rocq"
 
 let rocq_command args = Filename.quote_command rocq_bin args
 


### PR DESCRIPTION
Otherwise, it is not possible to use the shims when Rocq itself is installed, and not part of the workspace.

Note that the check is fine, because when the program actually runs, we know that the true `rocq` binary must be in place since there is a dependency on it in the dune rules.