### PR TITLE
upstream various basic ltac2 functions

### DIFF
--- a/ltac2-extra/theories/extra.v
+++ b/ltac2-extra/theories/extra.v
@@ -28,6 +28,7 @@ Require Export skylabs.ltac2.extra.internal.obj.
 Require Export skylabs.ltac2.extra.internal.oneshot.
 Require Export skylabs.ltac2.extra.internal.option.
 Require Export skylabs.ltac2.extra.internal.printf.
+Require Export skylabs.ltac2.extra.internal.reference.
 Require Export skylabs.ltac2.extra.internal.result.
 Require Export skylabs.ltac2.extra.internal.std.
 Require Export skylabs.ltac2.extra.internal.string.

--- a/ltac2-extra/theories/extra.v
+++ b/ltac2-extra/theories/extra.v
@@ -9,6 +9,7 @@
 
 Require Export skylabs.ltac2.extra.internal.array.
 Require Export skylabs.ltac2.extra.internal.char.
+Require Export skylabs.ltac2.extra.internal.compare.
 Require Export skylabs.ltac2.extra.internal.constr.
 Require Export skylabs.ltac2.extra.internal.control.
 Require Export skylabs.ltac2.extra.internal.coq_option.

--- a/ltac2-extra/theories/extra.v
+++ b/ltac2-extra/theories/extra.v
@@ -28,6 +28,7 @@ Require Export skylabs.ltac2.extra.internal.obj.
 Require Export skylabs.ltac2.extra.internal.oneshot.
 Require Export skylabs.ltac2.extra.internal.option.
 Require Export skylabs.ltac2.extra.internal.printf.
+Require Export skylabs.ltac2.extra.internal.result.
 Require Export skylabs.ltac2.extra.internal.std.
 Require Export skylabs.ltac2.extra.internal.string.
 Require Export skylabs.ltac2.extra.internal.transparent_state.

--- a/ltac2-extra/theories/extra.v
+++ b/ltac2-extra/theories/extra.v
@@ -13,6 +13,7 @@ Require Export skylabs.ltac2.extra.internal.constr.
 Require Export skylabs.ltac2.extra.internal.control.
 Require Export skylabs.ltac2.extra.internal.coq_option.
 Require Export skylabs.ltac2.extra.internal.env.
+Require Export skylabs.ltac2.extra.internal.fmap.
 Require Export skylabs.ltac2.extra.internal.fresh.
 Require Export skylabs.ltac2.extra.internal.fset.
 Require Export skylabs.ltac2.extra.internal.ident.

--- a/ltac2-extra/theories/extra.v
+++ b/ltac2-extra/theories/extra.v
@@ -23,6 +23,7 @@ Require Export skylabs.ltac2.extra.internal.intgraph.
 Require Export skylabs.ltac2.extra.internal.level_env.
 Require Export skylabs.ltac2.extra.internal.list.
 Require Export skylabs.ltac2.extra.internal.ltac1.
+Require Export skylabs.ltac2.extra.internal.message.
 Require Export skylabs.ltac2.extra.internal.misc.
 Require Export skylabs.ltac2.extra.internal.obj.
 Require Export skylabs.ltac2.extra.internal.oneshot.

--- a/ltac2-extra/theories/internal/compare.v
+++ b/ltac2-extra/theories/internal/compare.v
@@ -1,0 +1,17 @@
+(*
+ * Copyright (C) 2026 Skylabs AI, Inc.
+ *
+ * This software is distributed under the terms of the BedRock Open-Source
+ * License. See the LICENSE-BedRock file in the repository root for details.
+ *)
+
+Require Import skylabs.ltac2.extra.internal.init.
+
+(** Minor extensions to [Ltac2.String] *)
+Module Compare.
+  Import Ltac2.
+
+  Ltac2 compare_on (f : 'a -> 'b) (cmp : 'b -> 'b -> int) : 'a -> 'a -> int :=
+    fun x y => cmp (f x) (f y).
+
+End Compare.

--- a/ltac2-extra/theories/internal/compare.v
+++ b/ltac2-extra/theories/internal/compare.v
@@ -73,7 +73,7 @@ Module Comparison.
 
 End Comparison.
 
-(** Minor extensions to [Ltac2.String] *)
+(** Utilities for comparison functions *)
 Module Compare.
   Import Ltac2.
 

--- a/ltac2-extra/theories/internal/compare.v
+++ b/ltac2-extra/theories/internal/compare.v
@@ -7,6 +7,72 @@
 
 Require Import skylabs.ltac2.extra.internal.init.
 
+(** Functions to express comparisons in terms of a data type instead of integers. *)
+Module Comparison.
+  Import Ltac2.
+  Import Init.
+
+  Ltac2 Type 'a compare := 'a -> 'a -> comparison.
+
+  Ltac2 of_int (i : int) : comparison :=
+    if Int.lt i 0 then Lt
+    else if Int.gt i 0 then Gt
+    else Eq.
+
+  Ltac2 to_int (c : comparison) :=
+    match c with
+    | Lt => -1
+    | Eq => 0
+    | Gt => 1
+    end.
+
+  Ltac2 lift (cmp : 'a -> 'a -> int) : 'a -> 'a -> comparison :=
+    fun x y => of_int (cmp x y).
+
+  Ltac2 lower (cmp : 'a compare) : 'a -> 'a -> int :=
+    fun x y => to_int (cmp x y).
+
+  Ltac2 compare_on (f : 'a -> 'b) (cmp : 'b compare) : 'a -> 'a -> comparison :=
+    fun x y => cmp (f x) (f y).
+
+  Ltac2 lt (cmp : 'a compare) (x : 'a) (y : 'a) : bool :=
+    match cmp x y with
+    | Lt => true
+    | _ => false
+    end.
+  Ltac2 eq (cmp : 'a compare) (x : 'a) (y : 'a) : bool :=
+    match cmp x y with
+    | Eq => true
+    | _ => false
+    end.
+  Ltac2 gt (cmp : 'a compare) (x : 'a) (y : 'a) : bool :=
+    match cmp x y with
+    | Gt => true
+    | _ => false
+    end.
+  Ltac2 le (cmp : 'a compare) (x : 'a) (y : 'a) : bool :=
+    Bool.neg (gt cmp x y).
+  Ltac2 ge (cmp : 'a compare) (x : 'a) (y : 'a) : bool :=
+    Bool.neg (lt cmp x y).
+
+  Ltac2 rec lexicographical (cmp : (unit -> comparison) list) : comparison :=
+    match cmp with
+    | [] => Eq
+    | c :: cmps =>
+        let c := c () in
+        match c with
+        | Eq => lexicographical cmps
+        | _ => c
+        end
+    end .
+
+  Ltac2 lex2 (cmp_a : 'a compare) (cmp_b : 'b compare) : ('a * 'b) compare :=
+    fun (x0,x1) (y0,y1) => lexicographical [(fun () => cmp_a x0 y0);(fun () => cmp_b x1 y1)].
+  Ltac2 lex3 (cmp_a : 'a compare) (cmp_b : 'b compare) (cmp_c : 'c compare) : ('a * 'b * 'c) compare :=
+    fun (x0,x1,x2) (y0,y1,y2) => lexicographical [(fun () => cmp_a x0 y0);(fun () => cmp_b x1 y1);(fun () => cmp_c x2 y2)].
+
+End Comparison.
+
 (** Minor extensions to [Ltac2.String] *)
 Module Compare.
   Import Ltac2.

--- a/ltac2-extra/theories/internal/constr.v
+++ b/ltac2-extra/theories/internal/constr.v
@@ -481,15 +481,19 @@ Module Constr.
       Ltac2 invalid_arg (whence : string) (t : constr) : 'a :=
         invalid_arg' whence (Message.of_constr t).
 
+      Ltac2 of_app : constr -> (constr * constr array) := fun t =>
+        let rec go trm acc :=
+          match Unsafe.kind trm with
+          | Unsafe.App fn args => go fn (args :: acc)
+          | _ => (trm, Array.concat acc)
+          end in
+        go t [].
+
       Ltac2 of_ind_app_opt : constr -> (constr * constr array) option := fun t =>
-        match kind t with
-        | Ind _ _    => Some (t, Array.make 0 t)
-        | App c args =>
-            match kind c with
-            | Ind _ _ => Some (c, args)
-            | _       => None
-            end
-        | _          => None
+        let (c, args) := of_app t in
+        match kind c with
+        | Ind _ _ => Some (c, args)
+        | _       => None
         end.
 
       Ltac2 of_ind_app : constr -> constr * constr array := fun t =>
@@ -501,14 +505,10 @@ Module Constr.
 
       Ltac2 of_constructor_app_opt :
           constr -> (constr * instance * constr array) option := fun t =>
-        match kind t with
-        | Constructor _ inst => Some (t, inst, Array.make 0 t)
-        | App c args         =>
-            match kind c with
-            | Constructor _ inst => Some (c, inst, args)
-            | _       => None
-            end
-        | _          => None
+        let (c, args) := of_app t in
+        match kind c with
+        | Constructor _ inst => Some (c, inst, args)
+        | _       => None
         end.
 
       Ltac2 of_constructor_app : constr -> constr * instance * constr array :=

--- a/ltac2-extra/theories/internal/constr.v
+++ b/ltac2-extra/theories/internal/constr.v
@@ -68,6 +68,7 @@ Module Constr.
 
   Module Binder.
     Export Ltac2.Constr.Binder.
+    Import Ltac2.Bool.
 
     Ltac2 deconstruct (b : binder) : name * relevance * type :=
       (name b, relevance b, type b).
@@ -79,6 +80,11 @@ Module Constr.
 
     Ltac2 map_type : (type -> type) -> binder -> binder := fun f b =>
       let (name, r, ty) := deconstruct b in unsafe_make name r (f ty).
+
+    Ltac2 equal (b0 : binder) (b1 : binder) : bool :=
+      Option.equal Ident.equal (Binder.name b0) (Binder.name b1) &&
+        Constr.equal (Binder.type b0) (Binder.type b1).
+
   End Binder.
 
   Module Evar.

--- a/ltac2-extra/theories/internal/control.v
+++ b/ltac2-extra/theories/internal/control.v
@@ -73,6 +73,39 @@ Module Control.
   Ltac2 iter_hyps : (hyp -> unit) -> unit := fun f =>
     Control.enter (fun () => List.iter f (Control.hyps ())).
 
+  (** When listing terms in a goal, [goal_location] tells us where a given term is found. *)
+  Ltac2 Type goal_location := [ Hyp(ident) | DefValue(ident) | DefType(ident) | Concl ].
+
+  Ltac2 pp_goal_location : goal_location pp := fun () x =>
+    match x with
+    | Hyp h => fprintf "hypothesis %I" h
+    | DefValue h => fprintf "local definition %I (value)" h
+    | DefType h => fprintf "local definition %I (type)" h
+    | Concl => fprintf "conclusion"
+    end.
+
+  (** List all the terms in the current goal including the conclusion and the value of local
+      definitions. The hypotheses are local definitions are listed in the order in which they appear
+      and the concludsion is listed last *)
+  Ltac2 goal_constrs () :=
+    let hyp_to_term (h,def,ty) :=
+      match def with
+      | Some def => [(DefType h, ty);(DefValue h, def)]
+      | None => [(Hyp h, ty)]
+      end in
+    let hyps := List.flat_map hyp_to_term (hyps ()) in
+    List.append hyps [(Concl, goal ())].
+
+  (** Fold over all the terms that appear in the current goal. [fold_left_goal_constrs] starts with
+      the first hypothesis and moves down toward the conclusion while [fold_right_goal_constrs]
+      starts with the conclusion and moves up to the first hypothesis. *)
+  Ltac2 fold_left_goal_constrs (f : 'a -> goal_location -> constr -> 'a) (x0 : 'a) : 'a :=
+    let g x (loc, trm) := f x loc trm in
+    List.fold_left g x0 (goal_constrs ()).
+  Ltac2 fold_right_goal_constrs (f : goal_location -> constr -> 'a -> 'a) (x0 : 'a) : 'a :=
+    let g (loc, trm) x := f loc trm x in
+    List.fold_right g (goal_constrs ()) x0.
+
   (** [is_section_variable id] returns [true] if [id] is not a variable in the
       current environment. This seems to mean "being a section variable". *)
   Ltac2 @ external is_section_variable : ident -> bool :=

--- a/ltac2-extra/theories/internal/fmap.v
+++ b/ltac2-extra/theories/internal/fmap.v
@@ -1,0 +1,46 @@
+(*
+ * Copyright (C) 2022-2024 BlueRock Security, Inc.
+ *
+ * This software is distributed under the terms of the BedRock Open-Source
+ * License. See the LICENSE-BedRock file in the repository root for details.
+ *)
+
+Require Import skylabs.ltac2.extra.internal.init.
+Require Import skylabs.ltac2.extra.internal.printf.
+Require Import skylabs.ltac2.extra.internal.list.
+
+(** Minor extensions to [Ltac2.FMap] *)
+Module FMap.
+  Import Ltac2 Init Printf.
+  Export Ltac2.FMap .
+
+  Ltac2 alter (v0 : 'v) (k : 'k) (f : 'v -> 'v) (m : ('k,'v) FMap.t) : ('k,'v) FMap.t :=
+    match FMap.find_opt k m with
+    | Some v => FMap.add k (f v) m
+    | None => FMap.add k (f v0) m
+    end.
+
+  Ltac2 of_list (tag : 'k FSet.Tags.tag) (xs : ('k * 'a) list) : ('k, 'a) FMap.t :=
+    List.foldl (fun (k, v) => FMap.add k v) xs (FMap.empty tag).
+
+  Ltac2 filter_mapi (f : 'k -> 'a -> 'b option) (map : ('k, 'a) FMap.t) : ('k, 'b) FMap.t :=
+    let map := mapi f map in
+    let map := FMap.fold
+      (fun k v acc =>
+         if Option.is_none v then FMap.remove k acc
+      else acc ) map map in
+    FMap.mapi (fun _ v => Option.get v) map.
+
+  Ltac2 filteri (f : 'k -> 'a -> bool) : ('k, 'a) FMap.t -> ('k, 'a) FMap.t :=
+    filter_mapi
+      (fun k v => if f k v then Some v else None).
+
+  Ltac2 pp_fmap (pp_k : 'k pp) (pp_a : 'a pp) : ('k, 'a) FMap.t pp :=
+    fun () map =>
+    if FMap.is_empty map then
+      fprintf "{}"
+    else
+      let pp_pair () (k, a) := fprintf "(%a,%a)" pp_k k pp_a a in
+      fprintf "{%a}" (pp_list_sep ", " pp_pair) (FMap.bindings map).
+
+End FMap.

--- a/ltac2-extra/theories/internal/fmap.v
+++ b/ltac2-extra/theories/internal/fmap.v
@@ -35,7 +35,7 @@ Module FMap.
     filter_mapi
       (fun k v => if f k v then Some v else None).
 
-  Ltac2 pp_fmap (pp_k : 'k pp) (pp_a : 'a pp) : ('k, 'a) FMap.t pp :=
+  Ltac2 pp (pp_k : 'k pp) (pp_a : 'a pp) : ('k, 'a) FMap.t pp :=
     fun () map =>
     if FMap.is_empty map then
       fprintf "{}"

--- a/ltac2-extra/theories/internal/fresh.v
+++ b/ltac2-extra/theories/internal/fresh.v
@@ -7,6 +7,7 @@
 
 Require Import skylabs.ltac2.extra.internal.init.
 Require Import skylabs.ltac2.extra.internal.constr.
+Require Import skylabs.ltac2.extra.internal.string.
 
 (** Minor extensions to [Ltac2.Fresh] *)
 Module Fresh.
@@ -26,5 +27,17 @@ Module Fresh.
       Free.t * ident :=
     let name := Constr.Unsafe.RelDecl.name decl in
     for_name free name.
+
+  Ltac2 for_ssr_ident (free : Free.t) (n : ident) : Free.t * ident option :=
+    let ns := Ident.to_string n in
+    let ns := if String.equal ns "_" then "__" else ns in
+    let n' :=
+      Option.bind (String.remove_prefix "_" ns) (fun ns =>
+      Option.bind (String.remove_suffix "_" ns) (fun ns =>
+      Some (Fresh.for_name free (Ident.of_string ns)))) in
+    match n' with
+    | Some (free, n') => (free, Some n')
+    | None => (free, None)
+    end.
 
 End Fresh.

--- a/ltac2-extra/theories/internal/fset.v
+++ b/ltac2-extra/theories/internal/fset.v
@@ -28,7 +28,7 @@ Module FSet.
   Ltac2 of_list (tag : 'a FSet.Tags.tag) (xs : 'a list) : 'a FSet.t :=
     List.foldl FSet.add xs (FSet.empty tag).
 
-  Ltac2 pp_fset (pp_a : 'a pp) : 'a FSet.t pp :=
+  Ltac2 pp (pp_a : 'a pp) : 'a FSet.t pp :=
     fun () set =>
       fprintf "{%a}" (pp_list_sep "," pp_a) (FSet.elements set).
 

--- a/ltac2-extra/theories/internal/fset.v
+++ b/ltac2-extra/theories/internal/fset.v
@@ -5,12 +5,14 @@
  * License. See the LICENSE-BedRock file in the repository root for details.
  *)
 
-Require Import skylabs.ltac2.extra.internal.init.
 Require Import skylabs.ltac2.extra.internal.std.
+Require Import skylabs.ltac2.extra.internal.list.
+Require Import skylabs.ltac2.extra.internal.printf.
+Require Import skylabs.ltac2.extra.internal.init.
 
 (** Minor extensions to [Ltac2.FSet] *)
 Module FSet.
-  Import Ltac2 Init.
+  Import Ltac2 Init Printf.
   Export Ltac2.FSet.
 
   Module Import Tags.
@@ -22,4 +24,12 @@ Module FSet.
     Ltac2 @ external evar_tag : evar FSet.Tags.tag :=
       "rocq-runtime.plugins.ltac2" "fmap_evar_tag".
   End Tags.
+
+  Ltac2 of_list (tag : 'a FSet.Tags.tag) (xs : 'a list) : 'a FSet.t :=
+    List.foldl FSet.add xs (FSet.empty tag).
+
+  Ltac2 pp_fset (pp_a : 'a pp) : 'a FSet.t pp :=
+    fun () set =>
+      fprintf "{%a}" (pp_list_sep "," pp_a) (FSet.elements set).
+
 End FSet.

--- a/ltac2-extra/theories/internal/ident.v
+++ b/ltac2-extra/theories/internal/ident.v
@@ -58,4 +58,7 @@ Module Ident.
     make_app1 rep (make_lambda b tt).
   Ltac2 as_rep (id : ident) : constr := as_rep' () id.
 
+  Ltac2 compare (i0 : ident) (i1 : ident) : int :=
+    String.compare (Ident.to_string i0) (Ident.to_string i1).
+
 End Ident.

--- a/ltac2-extra/theories/internal/init.v
+++ b/ltac2-extra/theories/internal/init.v
@@ -34,4 +34,6 @@ Module Init.
   (** Type of pretty-printers for type ['a], suited to format string [%a]. *)
   Ltac2 Type 'a pp := unit -> 'a -> message.
 
+  Ltac2 Type comparison := [ Lt | Eq | Gt ].
+
 End Init.

--- a/ltac2-extra/theories/internal/init.v
+++ b/ltac2-extra/theories/internal/init.v
@@ -7,6 +7,10 @@
 
 Require Import skylabs.ltac2.extra.internal.plugin.
 
+(** Avoids getting module [Corelib.Classes.Init] to shadow [internal.init.Init] when imported after
+    [internal.init]. *)
+Require Stdlib.Strings.String.
+
 (** Minor extensions to [Ltac2.Init] *)
 Module Init.
   Import Ltac2.

--- a/ltac2-extra/theories/internal/list.v
+++ b/ltac2-extra/theories/internal/list.v
@@ -54,12 +54,12 @@ Module List.
       (xs : 'a list) (ys : 'b list) (acc : 'c) : 'c :=
     List.fold_right2 f xs ys acc.
 
-  Ltac2 rec first_some f xs :=
+  Ltac2 rec find_map_opt (f : 'a -> 'b option) (xs : 'a list) : 'b option :=
     match xs with
     | [] => None
     | x :: xs => match f x with
                  | Some x => Some x
-                 | None => first_some f xs
+                 | None => find_map_opt f xs
                  end
     end.
 

--- a/ltac2-extra/theories/internal/list.v
+++ b/ltac2-extra/theories/internal/list.v
@@ -12,16 +12,6 @@ Module List.
   Import Ltac2.
   Export Ltac2.List.
 
-  Ltac2 rec tails (xs : 'a list) : 'a list list :=
-    match xs with
-    | [] => []
-    | _x :: xs =>
-        xs :: tails xs
-    end .
-
-  Ltac2 inits (xs : 'a list) : 'a list list :=
-    List.map List.rev (tails (List.rev xs)).
-
   Ltac2 iteri2 (f : int -> 'a -> 'b -> unit) (xs : 'a list) (ys : 'b list) :=
     let rec loop i xs ys :=
       match (xs, ys) with

--- a/ltac2-extra/theories/internal/list.v
+++ b/ltac2-extra/theories/internal/list.v
@@ -76,6 +76,55 @@ Module List.
         end in
     go n xs [].
 
+  (* [bisect_partition ps xs]
+     Assuming for some predicate [ps : 'a -> bool], [ps xs = List.for_all p xs], [bisect_partition] is
+     characterized by [bisect_partition ps xs = List.partition p xs]. It offers better performances
+     then [List.for_all] in terms of the number of calls to [ps].
+
+     If every elements [x ∈ xs] satisfies [p x], [ps] is called only once.
+
+     If only one elemeent [x ∈ xs] does *not* satisfy [p x], then
+        i)  one of two halves of [xs], the one where [x] does *not* reside, can be partitioned using
+            a single call to [ps]
+        ii) the other half can again be split into two halves, one of which requires only a single
+            call to [ps].
+            ...
+        log n) xs can be repeatedly split into two parts and [ps] will be called [log n] times,
+               where [n = length xs].
+
+     If two elements, [x, y ∈ xs] do *not* satisfy [p], [ps] will be called at most [2 * log n]
+     times (if they are located in separate halves of [xs]) and at least [log n] times (if they are
+     next to each other).
+
+     The worse case performances obtain when no two consecutive elements of [xs] both satisfy [p]. [ps]
+     will then be called [2 * n]. They can be improved by switching to linear search for small sizes of [n].
+
+     Thus, the run goes from [O(log n)] to [O(n)] depending on the number and dispersion of elements of [xs]
+     which do not satisfy [p]
+   *)
+  Ltac2 bisect_partition (ps : 'a list -> bool) (xs : 'a list) : 'a list * 'a list :=
+    let min_len := 4 in
+    let rec go len xs (acc0, acc1) :=
+      if ps xs then
+        (List.append xs acc0, acc1)
+      else if Int.le len min_len then
+        let (ys0, ys1)  :=
+            List.partition
+                     (fun l => ps [l])
+                     xs in
+        let acc0 := List.append ys0 acc0 in
+        let acc1 := List.append ys1 acc1 in
+        (acc0, acc1)
+      else
+        let len0 := Int.div len 2 in
+        let len1 := Int.sub len len0 in
+        let (xs0,  xs1)  := split_at len0 xs in
+        let (acc0, acc1) := go len1 xs1 (acc0, acc1) in
+        let (acc0, acc1) := go len0 xs0 (acc0, acc1) in
+        (acc0, acc1) in
+    let len := List.length xs in
+    go len xs ([], []).
+
   (** Note: We have a "smart" list mapper in ML that works in the [Proofview]
       monad and uses Caml's [==] to promote sharing.
 

--- a/ltac2-extra/theories/internal/list.v
+++ b/ltac2-extra/theories/internal/list.v
@@ -12,6 +12,16 @@ Module List.
   Import Ltac2.
   Export Ltac2.List.
 
+  Ltac2 rec tails (xs : 'a list) : 'a list list :=
+    match xs with
+    | [] => []
+    | _x :: xs =>
+        xs :: tails xs
+    end .
+
+  Ltac2 inits (xs : 'a list) : 'a list list :=
+    List.map List.rev (tails (List.rev xs)).
+
   Ltac2 iteri2 (f : int -> 'a -> 'b -> unit) (xs : 'a list) (ys : 'b list) :=
     let rec loop i xs ys :=
       match (xs, ys) with
@@ -43,6 +53,28 @@ Module List.
   Ltac2 foldr2 (f : 'a -> 'b -> 'c -> 'c)
       (xs : 'a list) (ys : 'b list) (acc : 'c) : 'c :=
     List.fold_right2 f xs ys acc.
+
+  Ltac2 rec first_some f xs :=
+    match xs with
+    | [] => None
+    | x :: xs => match f x with
+                 | Some x => Some x
+                 | None => first_some f xs
+                 end
+    end.
+
+  Ltac2 split_at (n : int) (xs : 'a list) : 'a list * 'a list :=
+    let rec go n xs acc :=
+      if Int.le n 0 then
+        (List.rev acc, xs)
+      else
+        match xs with
+        | [] => (List.rev acc, [])
+        | x :: xs =>
+
+            go (Int.sub n 1) xs (x :: acc)
+        end in
+    go n xs [].
 
   (** Note: We have a "smart" list mapper in ML that works in the [Proofview]
       monad and uses Caml's [==] to promote sharing.

--- a/ltac2-extra/theories/internal/message.v
+++ b/ltac2-extra/theories/internal/message.v
@@ -1,0 +1,31 @@
+(*
+ * Copyright (C) 2026 Skylabs AI, Inc.
+ *
+ * This software is distributed under the terms of the BedRock Open-Source
+ * License. See the LICENSE-BedRock file in the repository root for details.
+ *)
+
+Require Import skylabs.ltac2.extra.internal.init.
+
+Module Message.
+  Import Ltac2.
+  Export Message.
+
+  Ltac2 join (sep : message) (msgs : message list) : message :=
+    match msgs with
+    | [] => Message.of_string ""
+    | x :: xs =>
+        let concat := List.fold_left Message.concat (Message.of_string "") in
+        List.fold_left
+          (fun x y => concat [x;sep;y])
+          x xs
+    end.
+
+  Ltac2 join_lines (msgs : message list) : message :=
+    join Message.force_new_line msgs.
+
+  (* Shadow [Message.concat] to fit the same naming convention as [List] *)
+  Ltac2 append := Message.concat.
+  Ltac2 concat (l : message list) := List.fold_right Message.concat l Message.empty.
+
+End Message.

--- a/ltac2-extra/theories/internal/option.v
+++ b/ltac2-extra/theories/internal/option.v
@@ -27,4 +27,17 @@ Module Option.
     | None   => ()
     | Some v => f v
     end.
+
+  Ltac2 or_else (x : 'a option) (y : unit -> 'a option) : 'a option :=
+    match x with
+    | Some x => Some x
+    | None => y ()
+    end.
+
+  Ltac2 to_list (x : 'a option) : 'a list :=
+    match x with
+    | Some x => [x]
+    | None => []
+    end.
+
 End Option.

--- a/ltac2-extra/theories/internal/printf.v
+++ b/ltac2-extra/theories/internal/printf.v
@@ -90,11 +90,17 @@ Module Printf.
     pp_list_sep "." pp_ident () ids.
 
   Ltac2 pp_short_ref : Std.reference pp := fun _ r =>
-    let ids := Env.path r in
-    let shorter := List.rev (ids :: List.tails ids) in
+    let rec suffixes xs acc :=
+      match xs with
+      | [] => acc
+      | _x :: xs' => suffixes xs' (xs :: acc)
+      end in
     let unambiguous path :=
       List.equal Reference.equal [r] (Env.expand path) in
-    let shorter := List.find unambiguous shorter in
+    let shorter :=
+      let ids := Env.path r in
+      let suffs := suffixes ids [] in
+      List.find unambiguous suffs in
     pp_list_sep "." pp_ident () shorter.
 
   (** Just enough info to know what case you forgot. *)

--- a/ltac2-extra/theories/internal/printf.v
+++ b/ltac2-extra/theories/internal/printf.v
@@ -6,10 +6,13 @@
  *)
 
 Require Import skylabs.ltac2.extra.internal.init.
+Require Import skylabs.ltac2.extra.internal.message.
+Require Import skylabs.ltac2.extra.internal.list.
+Require Import skylabs.ltac2.extra.internal.reference.
 
 (** Minor extensions to [Ltac2.Printf] *)
 Module Printf.
-  Import Ltac2 Init.
+  Import Ltac2 Init Message.
   Export Ltac2.Printf.
 
   (** Note: The following pretty-printers for base Ltac2 types are tied to
@@ -46,7 +49,7 @@ Module Printf.
 
   Ltac2 pp_list_sep : string -> 'a pp -> 'a list pp := fun sep pp () xs =>
     let sep := Message.of_string sep in
-    let rec loop xs (acc : message list) :=
+    let rec loop (xs : 'a list) (acc : message list) :=
       match xs with
       | [] => acc
       | x :: xs =>
@@ -59,7 +62,12 @@ Module Printf.
     in
     let msgs := loop xs [] in
     let msgs := List.rev msgs in
-    List.fold_left Message.concat (Message.of_string "") msgs.
+    Message.concat msgs.
+
+  Ltac2 pp_lines (pp : 'a pp) : 'a list pp :=
+    fun _ xs =>
+      Message.join_lines (List.map (pp ()) xs).
+
   Ltac2 pp_list : 'a pp -> 'a list pp := fun pp _ xs =>
     fprintf "[%a]" (pp_list_sep "; " pp) xs.
 
@@ -80,6 +88,14 @@ Module Printf.
   Ltac2 pp_reference : Std.reference pp := fun _ r =>
     let ids := Env.path r in
     pp_list_sep "." pp_ident () ids.
+
+  Ltac2 pp_short_ref : Std.reference pp := fun _ r =>
+    let ids := Env.path r in
+    let shorter := List.rev (ids :: List.tails ids) in
+    let unambiguous path :=
+      List.equal Reference.equal [r] (Env.expand path) in
+    let shorter := List.find unambiguous shorter in
+    pp_list_sep "." pp_ident () shorter.
 
   (** Just enough info to know what case you forgot. *)
   Ltac2 pp_kind_tag : Constr.Unsafe.kind pp := fun _ k =>
@@ -108,5 +124,21 @@ Module Printf.
       | Constr.Unsafe.Array _ _ _ _ => "Array"
       end
     in Message.of_string s.
+
+  Ltac2 pp_prefix (s : string) (pp : 'a pp) : 'a pp :=
+  fun _ x =>
+    Message.append (Message.of_string s) (pp () x).
+
+  Ltac2 pp_hbox (pp : 'a pp) : 'a pp :=
+    fun () x => Message.hbox (pp () x).
+
+  Ltac2 pp_vbox (i : int) (pp : 'a pp) : 'a pp :=
+    fun () x => Message.vbox i (pp () x).
+
+  Ltac2 pp_hvbox (i : int) (pp : 'a pp) : 'a pp :=
+    fun () x => Message.hvbox i (pp () x).
+
+  Ltac2 pp_hovbox (i : int) (pp : 'a pp) : 'a pp :=
+    fun () x => Message.hovbox i (pp () x).
 
 End Printf.

--- a/ltac2-extra/theories/internal/reference.v
+++ b/ltac2-extra/theories/internal/reference.v
@@ -1,0 +1,23 @@
+(*
+ * Copyright (C) 2026 Skylabs AI, Inc.
+ *
+ * This software is distributed under the terms of the BedRock Open-Source
+ * License. See the LICENSE-BedRock file in the repository root for details.
+ *)
+
+Require Import skylabs.ltac2.extra.internal.init.
+
+(** Some functions for [Std.reference]  *)
+Module Reference.
+  Import Ltac2 Init Std.
+
+  Ltac2 equal (r0 : Std.reference) (r1 : Std.reference) : bool :=
+    match r0, r1 with
+    | VarRef n0, VarRef n1 => Ident.equal n0 n1
+    | ConstRef n0, ConstRef n1 => Constant.equal n0 n1
+    | IndRef i0, IndRef i1 => Ind.equal i0 i1
+    | ConstructRef c0, ConstructRef c1 => Constructor.equal c0 c1
+    | _, _ => false
+    end.
+
+End Reference.

--- a/ltac2-extra/theories/internal/result.v
+++ b/ltac2-extra/theories/internal/result.v
@@ -1,0 +1,28 @@
+(*
+ * Copyright (C) 2022-2024 BlueRock Security, Inc.
+ *
+ * This software is distributed under the terms of the BedRock Open-Source
+ * License. See the LICENSE-BedRock file in the repository root for details.
+ *)
+
+Require Import skylabs.ltac2.extra.internal.init.
+
+(** Some functions for [result] type *)
+Module Result.
+  Import Ltac2 Init.
+
+  Ltac2 mret (x : 'a) : 'a result := Val x.
+
+  Ltac2 bind x f :=
+    match x with
+    | Val x => f x
+    | Err e => Err e
+    end.
+
+  Ltac2 or_else (x : 'a result) (y : unit -> 'a result) : 'a result :=
+    match x with
+    | Val x => Val x
+    | Err _ => y ()
+    end.
+
+End Result.

--- a/ltac2-extra/theories/internal/std.v
+++ b/ltac2-extra/theories/internal/std.v
@@ -8,6 +8,7 @@
 Require Import skylabs.ltac2.extra.internal.plugin.
 Require Import skylabs.ltac2.extra.internal.control.
 Require Import skylabs.ltac2.extra.internal.constr.
+Require Import skylabs.ltac2.extra.internal.fresh.
 Require Import skylabs.ltac2.extra.internal.misc.
 
 (** Minor extensions to [Ltac2.Std] *)
@@ -141,4 +142,23 @@ Module Std.
 
   Ltac2 @external typeclasses_eauto_dbs : tc_config -> hint_db list -> unit :=
     "ltac2_extensions" "typeclasses_eauto_dbs".
+
+  Ltac2 rename_ssr_vars () :=
+    let free :=
+      let free := Fresh.Free.of_goal () in
+      Ref.ref free in
+    let for_ssr_ident n :=
+      let fr := Ref.get free in
+      let (fr, n) := Fresh.for_ssr_ident fr n in
+      Ref.set free fr ;
+      n in
+    let hyps := Control.hyps () in
+    let f (h, _def, _ty) :=
+      match for_ssr_ident h with
+      | Some h' => Some (h, h')
+      | None => None
+      end in
+    let ren := List.map_filter f hyps in
+    Std.rename ren.
+
 End Std.

--- a/ltac2-extra/theories/internal/string.v
+++ b/ltac2-extra/theories/internal/string.v
@@ -50,12 +50,12 @@ Module String.
   Ltac2 newline () : string :=
     String.make 1 (Char.of_int 10).
 
-  Ltac2 is_prefix_of (pre : string) (s : string) : bool :=
+  Ltac2 starts_with (pre : string) (s : string) : bool :=
     let len_pre := String.length pre in
     let len_s := String.length s in
     Int.le len_pre len_s && String.equal pre (String.sub s 0 len_pre).
 
-  Ltac2 is_suffix_of (suff : string) (s : string) : bool :=
+  Ltac2 ends_with (suff : string) (s : string) : bool :=
     let len_suff := String.length suff in
     let len_s := String.length s in
     let len_pre := Int.sub len_s len_suff in

--- a/ltac2-extra/theories/internal/string.v
+++ b/ltac2-extra/theories/internal/string.v
@@ -8,7 +8,8 @@
 Require Import skylabs.ltac2.extra.internal.init.
 Require Import skylabs.ltac2.extra.internal.constr.
 Require Import skylabs.ltac2.extra.internal.char.
-Require Import Stdlib.Strings.String.
+
+Import Stdlib.Strings.String.
 
 (** Minor extensions to [Ltac2.String] *)
 Module String.

--- a/ltac2-extra/theories/internal/string.v
+++ b/ltac2-extra/theories/internal/string.v
@@ -80,7 +80,7 @@ Module String.
     else
       None.
 
-  (* Synonym meant fit the same naming convention as [List] *)
+  (* Synonym meant to fit the same naming convention as [List] *)
   Ltac2 append := app.
 
 End String.

--- a/ltac2-extra/theories/internal/string.v
+++ b/ltac2-extra/theories/internal/string.v
@@ -12,7 +12,7 @@ Require Import Stdlib.Strings.String.
 
 (** Minor extensions to [Ltac2.String] *)
 Module String.
-  Import Ltac2 Init.
+  Import Ltac2 Init Ltac2.Bool.
   Export Ltac2.String.
 
   (** [sub s pos len] returns a new byte sequence of length len,
@@ -48,4 +48,38 @@ Module String.
 
   Ltac2 newline () : string :=
     String.make 1 (Char.of_int 10).
+
+  Ltac2 is_prefix_of (pre : string) (s : string) : bool :=
+    let len_pre := String.length pre in
+    let len_s := String.length s in
+    Int.le len_pre len_s && String.equal pre (String.sub s 0 len_pre).
+
+  Ltac2 is_suffix_of (suff : string) (s : string) : bool :=
+    let len_suff := String.length suff in
+    let len_s := String.length s in
+    let len_pre := Int.sub len_s len_suff in
+    Int.le len_suff len_s && String.equal suff (String.sub s len_pre len_suff).
+
+  Ltac2 remove_prefix (pre : string) (s : string) : string option :=
+    let len_pre := String.length pre in
+    let len_s := String.length s in
+    let len_suff := Int.sub len_s len_pre in
+    if Int.le len_pre len_s &&
+         String.equal pre (String.sub s 0 len_pre) then
+      Some (String.sub s len_pre len_suff)
+    else None.
+
+  Ltac2 remove_suffix (suff : string) (s : string) : string option :=
+    let len_suff := String.length suff in
+    let len_s := String.length s in
+    let len_pre := Int.sub len_s len_suff in
+    if Int.le len_suff len_s &&
+         String.equal suff (String.sub s len_pre len_suff) then
+      Some (String.sub s 0 len_pre)
+    else
+      None.
+
+  (* Synonym meant fit the same naming convention as [List] *)
+  Ltac2 append := app.
+
 End String.


### PR DESCRIPTION
Upstream a number of convenience Ltac2 functions about:
* `string`
* `option`
* `ident`
* `list`
* `fset`/`fmap`
* `binder`
* `reference`
* `message`
* `pp`
* `comparison`

As well as three novel functionalities:
* `Control.fold_left_goal_constrs` (and others) to traverse all the terms in a goal regardless where they appear;
* `Std.rename_ssr_vars` to rename all variables using the ssreflect naming scheme in context to remove the underscores and avoid warnings / errors;
* `List.bisect_partition` to partition a list using a predicate between the elements that satisfy the predicates and those that don't. It is built to minimize the number of calls to the predicate `p : 'a list -> bool` when testing multiple elements at once is less than linearly more expensive than testing a single element. It yields better performances than the straightforward `partition` when relatively few elements in the list *do not* satisfy the predicate. (see comment in code for more information)