### PR TITLE
[ltac2-logger] Fix bug (dynamic typing assertion).

### DIFF
--- a/ltac2-logger/plugin/ltac2_format.ml
+++ b/ltac2-logger/plugin/ltac2_format.ml
@@ -32,6 +32,7 @@ let build_msg : Environ.env -> Evd.evar_map -> Tac2types.format list ->
     let _Int i = Int(Tac2ffi.to_int i) in
     let _Constr c = Constr(env, sigma, Tac2ffi.to_constr c) in
     let _Ident i = Ident(Tac2ffi.to_ident i) in
+    let _Pp p = Pp(Tac2ffi.to_pp p) in
     let _Msg m = Msg(Tac2ffi.to_ext msg_tag m) in
     let _Thunk f x =
       let thunk () =
@@ -78,8 +79,8 @@ let build_msg : Environ.env -> Evd.evar_map -> Tac2types.format list ->
         build (_Thunk f x :: acc) fs args
     | (FmtAlpha0     :: fs, f :: x :: args) ->
         build (_Thunk0 f x :: acc) fs args
-    | (FmtMessage    :: fs, m      :: args) ->
-        build (_Msg m :: acc) fs args
+    | (FmtMessage    :: fs, p      :: args) ->
+        build (_Pp p :: acc) fs args
     | (_                  , _             ) -> assert false
   in
   build [] fs args


### PR DESCRIPTION
This makes the following example (provided by @Janno) work:
```
Require Import skylabs.ltac2.logger.logger.
Require Import Ltac2.Printf Ltac2.Init.

Ltac2 Log Flag test.
Set SL Debug "test=1".
Set SL Direct Log.
Ltac2 test1 : message -> unit := fun msg => printf "%m" msg.
Ltac2 test2 : message -> unit := fun msg => log[test] "%m" msg.
Ltac2 msg : unit -> message := fun () => fprintf "%t" 'True.

Succeed Ltac2 Eval test1 (msg ()).
Succeed Ltac2 Eval test2 (msg ()).
```