### PR TITLE
Remove the initial state from [Sts]

### DIFF
--- a/rocq-skylabs-iris/theories/base_logic/lib/spectra.v
+++ b/rocq-skylabs-iris/theories/base_logic/lib/spectra.v
@@ -553,12 +553,12 @@ Module Step.
 End Step.
 
 (*** Satisfiability
-  
+
   We provide a simple invariant to demonstrate that Spectra is satisfiable.
   The definition of [root_inv] below bundles the authoritative state of
   the LTS but does **not** connect it to the physical state of the system,
   which is necessary to use Spectra to prove an actual refinement.
-  
+
   In order to connect to the physical state, the WP of the physical system
   must expose the visible events that it takes (which can be exposed as a trace).
   Using this trace we can construct a true root invariant by bundling the physical
@@ -573,12 +573,12 @@ Section with_app.
   Context `{Ghostly PROP} `{!BiFUpd PROP} `{!BiBUpdFUpd PROP}.
   Context `{root : !App.app, E : coPset}.
 
-  Definition root_inv ns γroot :=
+  Definition root_inv ns γroot (init_state : _ -> Prop) :=
     inv ns $
       Exists root_set init_st,
         AuthSet.auth γroot root_set **
         [| ∃ s, s ∈ root_set |] **
-        [| root.(lts).(Sts._init_state) init_st |] **
+        [| init_state init_st |] **
         [| ∀ s, s ∈ root_set ->
            ∃ evts, reachable root.(lts) init_st evts s |].
 
@@ -586,8 +586,8 @@ Section with_app.
       opening the invariant results in a later. to move the later inside using [bi.later_exist],
       we need that the type is inhabited.
   *)
-  Lemma alloc_updater ns γroot {inh: Inhabited (root.(lts).(Sts._state))}:
-    root_inv ns γroot |-- Step.updater root (↑ns) γroot.
+  Lemma alloc_updater ns γroot init {inh: Inhabited (root.(lts).(Sts._state))}:
+    root_inv ns γroot init |-- Step.updater root (↑ns) γroot.
   Proof using All.
     iIntros "#inv". rewrite Step.updater_unseal.
     iIntros "!#" (sset nonempty safe) "frag".

--- a/rocq-skylabs-iris/theories/wp_io/refinement/adequacy.v
+++ b/rocq-skylabs-iris/theories/wp_io/refinement/adequacy.v
@@ -31,6 +31,7 @@ Section with_lang.
   Context {absE : Type}.
   Context (R : absE -> (Compose.event cfg) -> Prop).
   Context {absLTS : LTS absE}.
+  Variable is_init_state : absLTS.(Sts._state) -> Prop.
 
   (**
   If the client can prove
@@ -55,7 +56,7 @@ Section with_lang.
     (* WP of e *)
     (∀ `{Hinv : !invGS_gen HasNoLc Σ},
       ⊢ |={⊤}=>
-          ∃ s_init, [| absLTS.(Sts._init_state) s_init |] ∗
+          ∃ s_init, [| is_init_state s_init |] ∗
           ∀ γ_abs, AuthSet.frag γ_abs {[s_init]} -∗
           ∃ (stateI : state Λ → nat → list (observation Λ) → nat → iProp Σ)
             (Φ : val Λ → iProp Σ)
@@ -64,10 +65,10 @@ Section with_lang.
           let _ : irisGS_gen Λ (iPropI Σ) :=
             IrisG stateI fork_post num_laters_per_step state_interp_mono in
           stateI σ1 0 κs 0 ∗
-          root.wp_embed R γ_abs MaybeStuck top e Φ) →
+          root.wp_embed R is_init_state γ_abs MaybeStuck top e Φ) →
     language.nsteps (Λ:=Λ) n ([e], σ1) κs (t2, σ2) →
     ∃ s_init s tr_abs,
-      absLTS.(Sts._init_state) s_init ∧
+      is_init_state s_init ∧
       reachable absLTS s_init tr_abs s ∧
       let vis_abs := filter is_Some tr_abs in
       let vis_con := filter is_Some κs.*1 in
@@ -82,10 +83,10 @@ Section with_lang.
     (* extracting user's WP proof *)
     iMod (Hwp Hinv) as (s_init INIT) "WP".
     (* setting up ghost state for refinement *)
-    iMod (root.trace_refine_alloc R s_init INIT) as (γ_abs) "[F RT]".
+    iMod (root.trace_refine_alloc R is_init_state s_init INIT) as (γ_abs) "[F RT]".
     iDestruct ("WP" with "F") as (stateI Φ fork_post ?) "[SI WP]".
     iIntros "!>".
-    iExists (root.refine_embed_stateI R γ_abs), [Φ], _, _.
+    iExists (root.refine_embed_stateI R is_init_state γ_abs), [Φ], _, _.
     iFrame "WP".
     rewrite /root.refine_embed_stateI INIT_EMPTY. iFrame "RT SI".
     iSplitR; [done|].
@@ -120,24 +121,25 @@ Section with_lang.
   Context {absE : Type}.
   Context (R : absE -> (Compose.event cfg) -> Prop).
   Context {absLTS : LTS absE}.
+  Variable is_init_state : absLTS.(Sts._state) -> Prop.
 
   #[local] Lemma ghost_trace_refine_inv_alloc {Σ} `{!invGS_gen hlc Σ}
       `{!AuthSet.G Σ (lts_state absLTS)}             (* for abstract state *)
       `{!mono_list.G Σ (option (Compose.event cfg))} (* for concrete trace *)
       N E
-      s_init (INIT : absLTS.(Sts._init_state) s_init) :
+      s_init (INIT : is_init_state s_init) :
     ⊢@{iPropI Σ}
-      |={E}=> ∃ γ_con γ_abs, root.ghost_trace_refine_inv R γ_con γ_abs N ∗
+      |={E}=> ∃ γ_con γ_abs, root.ghost_trace_refine_inv R is_init_state γ_con γ_abs N ∗
         AuthSet.frag γ_abs {[s_init]} ∗
         mono_list.half γ_con [].
   Proof.
     iMod (mono_list.half_alloc []) as (γ_con) "[h1 h2]".
-    iMod (root.trace_refine_alloc R s_init INIT) as (γ_abs) "[F RT]".
+    iMod (root.trace_refine_alloc R is_init_state s_init INIT) as (γ_abs) "[F RT]".
     iExists γ_con, γ_abs. iFrame.
 
     (* TODO cleanup : inlining [skylabs.iris.extra.base_logic.iprop_invariants]
       because that one is fixed to the default [invGS_gen HasLc] *)
-    iMod (own_inv_alloc N E (root.ghost_trace_refine R γ_con γ_abs) with "[-]") as "#INV".
+    iMod (own_inv_alloc N E (root.ghost_trace_refine R is_init_state γ_con γ_abs) with "[-]") as "#INV".
     { iNext. iExists []. by iFrame. }
     rewrite /root.ghost_trace_refine_inv inv_eq.
     iIntros "!>" (E' SubE') "!#".
@@ -169,9 +171,9 @@ Section with_lang.
     (* WP of e *)
     (∀ `{Hinv : !invGS_gen HasNoLc Σ},
       ⊢ |={⊤}=>
-          ∃ s_init, [| absLTS.(Sts._init_state) s_init |] ∗
+          ∃ s_init, [| is_init_state s_init |] ∗
           ∀ γ_abs γ_con,
-          root.ghost_trace_refine_inv R γ_con γ_abs N -∗
+          root.ghost_trace_refine_inv R is_init_state γ_con γ_abs N -∗
           AuthSet.frag γ_abs {[s_init]} -∗
           ∃ (stateI : state Λ → nat → list (observation Λ) → nat → iProp Σ)
             (Φ : val Λ → iProp Σ)
@@ -183,7 +185,7 @@ Section with_lang.
           root.wp_inv γ_con MaybeStuck top e Φ) →
     language.nsteps (Λ:=Λ) n ([e], σ1) κs (t2, σ2) →
     ∃ s_init s tr_abs,
-      absLTS.(Sts._init_state) s_init ∧
+      is_init_state s_init ∧
       reachable absLTS s_init tr_abs s ∧
       let vis_abs := filter is_Some tr_abs in
       let vis_con := filter is_Some κs.*1 in

--- a/rocq-skylabs-iris/theories/wp_io/refinement/inv.v
+++ b/rocq-skylabs-iris/theories/wp_io/refinement/inv.v
@@ -34,6 +34,7 @@ Section trace.
   Context {absE conE : Type}.
   Context (R : absE -> conE -> Prop).
   Context {absLTS : LTS absE}.
+  Variable is_init_state : absLTS.(Sts._state) -> Prop.
 
   Context {PROP : bi} `{!Ghostly PROP}.
   Context `{!HasUsualOwn PROP (auth_setR absLTS.(lts_state))}.
@@ -52,7 +53,7 @@ Section trace.
     (∃ ss,
       AuthSet.auth γ_abs ss ∗
       [| ∃ s, s ∈ ss |] ∗
-      ∃ s_init, [| absLTS.(Sts._init_state) s_init |] ∗
+      ∃ s_init, [| is_init_state s_init |] ∗
       [| ∀ s, s ∈ ss -> reachable absLTS s_init tr_abs s |]) ∗
       (* related *)
       [|  let vis_abs := filter is_Some tr_abs in
@@ -61,7 +62,7 @@ Section trace.
           Forall2 (option_Forall2 R) vis_abs vis_con
       |].
 
-  Lemma trace_refine_alloc s_init (INIT : absLTS.(Sts._init_state) s_init) :
+  Lemma trace_refine_alloc s_init (INIT : is_init_state s_init) :
     ⊢ |==> ∃ γ, AuthSet.frag γ {[s_init]} ∗ trace_refine γ [].
   Proof.
     rewrite /trace_refine.
@@ -115,6 +116,7 @@ Section stateI.
     Context {absE : Type}.
     Context (R : absE -> (Compose.event cfg) -> Prop).
     Context {absLTS : LTS absE}.
+    Variable is_init_state : absLTS.(Sts._state) -> Prop.
 
     Context `{!HasUsualOwn PROP (auth_setR absLTS.(lts_state))}.
 
@@ -125,10 +127,10 @@ Section stateI.
     *)
     Definition refine_embed_stateI (γ_abs : AuthSet.gname)
         (σ : state Λ) (ns : nat) (κs : list (observation Λ)) (nt : nat) : PROP :=
-      trace_refine R γ_abs σ.1.*1 ∗
+      trace_refine R is_init_state γ_abs σ.1.*1 ∗
       state_interp σ ns κs nt.
 
-    Program Definition refine_embed_irisGS_gen (γ_abs : AuthSet.gname)
+    #[program] Definition refine_embed_irisGS_gen (γ_abs : AuthSet.gname)
         : irisGS_gen Λ PROP :=
       IrisG (refine_embed_stateI γ_abs) fork_post num_laters_per_step _.
     Next Obligation.

--- a/rocq-skylabs-iris/theories/wp_io/refinement/wp_io.v
+++ b/rocq-skylabs-iris/theories/wp_io/refinement/wp_io.v
@@ -53,7 +53,7 @@ NES.Begin root.
 
     TODO (FM-3811):
     In the decomposition of the framework, ownership is not atomically passed
-    one app C1 to another app C2 or vice versa. The updates of the components
+    from app C1 to another app C2 or vice versa. The updates of the components
     are meant to be executed one after the other, that is, one must run all
     C1's updates, using all available invariants from the masks, and restablish
     the invariants again, before C2's updates can be run, which can all use
@@ -208,9 +208,9 @@ Section wp_io.
     Context `{!BiBUpdFUpd PROP}.
 
     (* TODO : not handling non-stuck ness yet. *)
-    Lemma wp_io_run_embed (γ_abs : AuthSet.gname) E e Φ :
+    Lemma wp_io_run_embed init (γ_abs : AuthSet.gname) E e Φ :
       wp_io absA R γ_abs MaybeStuck E e Φ ⊢
-      wp_embed R γ_abs MaybeStuck top e Φ.
+      wp_embed R init γ_abs MaybeStuck top e Φ.
     Proof using All.
       iIntros "WP".
       iLöb as "IH" forall (e).

--- a/rocq-skylabs-prelude/theories/sts.v
+++ b/rocq-skylabs-prelude/theories/sts.v
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2020 BlueRock Security, Inc.
+ * Copyright (C) 2020-2026 SkyLabs AI, Inc.
  *
  * This software is distributed under the terms of the BedRock Open-Source License.
  * See the LICENSE-BedRock file in the repository root for details.
@@ -21,8 +21,6 @@ Module Sts.
   Record sts {Label : Type} : Type := {
     (** State type *)
     _state      :> Type
-    (** Initial state predicate *)
-  ; _init_state : _state -> Prop
 
     (** Step relation of the LTS
     [None] means [Tau]. *)
@@ -99,8 +97,7 @@ Module Sts.
     This allows you to translate events in one [t] to another [t]
     *)
     Definition map  : sts L' :=
-      {| _init_state := STS.(_init_state)
-       ; _step := Map_step |}.
+      {| _step := Map_step |}.
 
   End map.
 
@@ -155,8 +152,7 @@ Module Sts.
     transition for the composed system.
     *)
     Definition par : sts e :=
-      {| _init_state '(l,r) := L.(_init_state) l /\ R.(_init_state) r
-       ; _step := Par_step |}.
+      {| _step := Par_step |}.
 
   End par.
 
@@ -167,13 +163,11 @@ Module Sts.
   }.
   #[global] Arguments Build_t {_} _.
   Definition State (x : t) := x.(_sts).(_state).
-  Definition init_state (x : t) : State x -> Prop := x.(_sts).(_init_state).
   Definition step (x : t) : State x -> option x.(Label) -> State x -> Prop :=
     x.(_sts).(_step).
 
   (* Let these simplify as if they were projections. *)
   #[global] Arguments State !_ /.
-  #[global] Arguments init_state !_ /.
   #[global] Arguments step !_ /.
 End Sts.
 
@@ -210,8 +204,6 @@ Module Compose.
     Implicit Types (n : name sf).
 
     Definition State : Type := ∀ n, Sts.State (sts_name sf n).
-
-    Definition init_state (s: State) : Prop := ∀ n, Sts.init_state _ (s n).
 
     Definition eq_except (n : list _) (s s' : State) :=
       ∀ n', n' ∉ n -> s n' = s' n'.
@@ -254,7 +246,6 @@ Module Compose.
 
     Definition compose_lts : Sts.sts (external_event sf) := {|
       Sts._state := State;
-      Sts._init_state := init_state;
       (* a step of the composition is either:
       - an externally visible step which comes from some constituent component n
       - a tau step, which is either
@@ -386,7 +377,6 @@ End Compose.
 #[global] Notation LTS := Sts.sts.
 #[global] Notation lts_state := Sts._state.
 #[global] Notation lts_step := Sts._step.
-#[global] Notation lts_init_state := Sts._init_state.
 
 (* TODO: unify [reachable] and [Sts.step_star]
 The following lemma should hold:


### PR DESCRIPTION
Having the initial state is not very Markovian and it gets in the way. Operations that require the explicit state can take it separately.