### PR TITLE
More robust implicit member generation

### DIFF
--- a/rocq-skylabs-brick/plugin/src/cpp2v.ml
+++ b/rocq-skylabs-brick/plugin/src/cpp2v.ml
@@ -11,17 +11,30 @@ type report_level =
   | Warn
   | Error
 
+type attrs = {
+  check_duplicates : report_level option;
+  elaborate : bool;
+  check_types : bool;
+}
+
 let attributes =
   let open Attributes in
   let open Attributes.Notations in
   let name = "duplicates" in
-  (Attributes.qualify_attribute "duplicates"
+  let duplicates =
+    Attributes.qualify_attribute "duplicates"
     @@ attribute_of_list [
-        ("warn", single_key_parser ~name ~key:"warn" Warn);
-        ("error", single_key_parser ~name ~key:"error" Error);
-        ("ignore", single_key_parser ~name ~key:"ignore" Ignore);
-    ]) ++
-  (map (fun x -> x = Some true) (Attributes.bool_attribute ~name:"elaborate"))
+      ("warn", single_key_parser ~name ~key:"warn" Warn);
+      ("error", single_key_parser ~name ~key:"error" Error);
+      ("ignore", single_key_parser ~name ~key:"ignore" Ignore);
+    ]
+  in
+  let bool_attribute name =
+    map (fun x -> x = Some true) (Attributes.bool_attribute ~name)
+  in
+  map (fun ((check_duplicates, elaborate), check_types) ->
+      { check_duplicates; elaborate; check_types })
+    ((duplicates ++ bool_attribute "elaborate") ++ bool_attribute "check_types")
 
 let lib_ref t =
   Rocqlib.lib_ref ("skylabs.lang.cpp.parser.translation_unit." ^ t)
@@ -59,9 +72,9 @@ let force_body (t : _ Declarations.pconstant_body) =
   | Declarations.Def d -> d
   | _ -> assert false
 
-let cpp_command (attrs : report_level option * bool) name (abi : Constrexpr.constr_expr option) (defns : Constrexpr.constr_expr list) =
+let cpp_command (attrs : attrs) name (abi : Constrexpr.constr_expr option) (defns : Constrexpr.constr_expr list) =
   (* Create the definition *)
-  let (check_duplicates, elaborate) = attrs in
+  let { check_duplicates; _ } = attrs in
   let env = Global.env() in
   let e_decl = to_econstr (lib_ref "t") in
   let e_decl_skip = to_econstr (lib_ref "skip") in
@@ -160,8 +173,8 @@ let temp_file ?(prefix="ocaml_temp_") ?(suffix=".tmp") content =
       let _ = try Sys.remove temp_file with _ -> () in
       raise e
 
-let cpp_command_prog (attrs : report_level option * bool) name flags prog =
-  let (check_duplicates, elaborate) = attrs in
+let cpp_command_prog (attrs : attrs) name flags prog =
+  let { check_duplicates; elaborate; check_types } = attrs in
   let temp_cpp , unlink = temp_file ~suffix:".cpp" prog in
   let temp_v = Filename.temp_file "_" ".v" in
   let flags =
@@ -181,6 +194,7 @@ let cpp_command_prog (attrs : report_level option * bool) name flags prog =
     "-o"; temp_v;
     temp_cpp] @
     (if elaborate then ["--elaborate"] else ["--no-elaborate"]) @
+    (if check_types then ["--check-types"] else []) @
     (match check_duplicates with
      | None -> []
      | Some Error -> ["-attributes";"duplicates(error)"]

--- a/rocq-skylabs-brick/tests/compiler_provided.expected
+++ b/rocq-skylabs-brick/tests/compiler_provided.expected
@@ -1,0 +1,52 @@
+     = Some
+         (Oconstructor
+            {|
+              c_class := "C";
+              c_params := [];
+              c_cc := CC_C;
+              c_arity := Ar_Definite;
+              c_exception := exception_spec.NoThrow;
+              c_body := Some (CompilerProvided ([], Sseq []))
+            |})
+     : option ObjValue
+     = Some
+         (Odestructor
+            {|
+              d_class := "C";
+              d_cc := CC_C;
+              d_exception := exception_spec.Unknown;
+              d_body := Some Defaulted
+            |})
+     : option ObjValue
+     = Some
+         (Omethod
+            {|
+              m_return := "C&";
+              m_class := "C";
+              m_this_qual := QM;
+              m_params := [("#0"%pstring, "const C&"%cpp_type)];
+              m_cc := CC_C;
+              m_arity := Ar_Definite;
+              m_exception := exception_spec.NoThrow;
+              m_body :=
+                Some
+                  (CompilerProvided
+                     (Sseq [Sreturn (Some (Ederef (Ethis "C*") "C"))]))
+            |})
+     : option ObjValue
+     = Some
+         (Omethod
+            {|
+              m_return := "C&";
+              m_class := "C";
+              m_this_qual := QM;
+              m_params := [("#0"%pstring, "C&&"%cpp_type)];
+              m_cc := CC_C;
+              m_arity := Ar_Definite;
+              m_exception := exception_spec.NoThrow;
+              m_body :=
+                Some
+                  (CompilerProvided
+                     (Sseq [Sreturn (Some (Ederef (Ethis "C*") "C"))]))
+            |})
+     : option ObjValue

--- a/rocq-skylabs-brick/tests/compiler_provided.v
+++ b/rocq-skylabs-brick/tests/compiler_provided.v
@@ -1,0 +1,18 @@
+Require Import skylabs.lang.cpp.cpp.
+Require Import skylabs.lang.cpp.parser.plugin.cpp2v.
+
+#[duplicates(warn)]
+cpp.prog source prog cpp:{{
+   struct C {};
+
+   void test() {
+       C c;
+       c = c;
+       c = static_cast<C&&>(c);
+   }
+}}.
+
+Eval vm_compute in source.(symbols) !! "C::C()"%cpp_name.
+Eval vm_compute in source.(symbols) !! "C::~C()"%cpp_name.
+Eval vm_compute in source.(symbols) !! "C::operator=(const C&)"%cpp_name.
+Eval vm_compute in source.(symbols) !! "C::operator=(C&&)"%cpp_name.

--- a/rocq-skylabs-brick/tests/implicit_members.expected
+++ b/rocq-skylabs-brick/tests/implicit_members.expected
@@ -1,0 +1,226 @@
+     = ("C1::C1()"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C1";
+               c_params := [];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.Unknown;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C1::~C1()"%cpp_name,
+        Some
+          (Odestructor
+             {|
+               d_class := "C1";
+               d_cc := CC_C;
+               d_exception := exception_spec.Unknown;
+               d_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C1::C1(const C1&)"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C1";
+               c_params := [("#0"%pstring, "const C1&"%cpp_type)];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.Unknown;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C1::C1(const C1&&)"%cpp_name, None)
+     : name * option ObjValue
+     = ("C1::operator=(const C1&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "const C1&";
+               m_class := "C1";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "const C1&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C1::operator=(C1&&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "C1&";
+               m_class := "C1";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "C1&&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C2::C2()"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C2";
+               c_params := [];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.NoThrow;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C2::~C2()"%cpp_name,
+        Some
+          (Odestructor
+             {|
+               d_class := "C2";
+               d_cc := CC_C;
+               d_exception := exception_spec.Unknown;
+               d_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C2::C2(const C2&)"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C2";
+               c_params := [("#0"%pstring, "const C2&"%cpp_type)];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.Unknown;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C2::C2(const C2&&)"%cpp_name, None)
+     : name * option ObjValue
+     = ("C2::operator=(const C2&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "const C2&";
+               m_class := "C2";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "const C2&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C2::operator=(C2&&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "C2&";
+               m_class := "C2";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "C2&&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C3::C3()"%cpp_name, None)
+     : name * option ObjValue
+     = ("C3::~C3()"%cpp_name,
+        Some
+          (Odestructor
+             {|
+               d_class := "C3";
+               d_cc := CC_C;
+               d_exception := exception_spec.Unknown;
+               d_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C3::C3(const C3&)"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C3";
+               c_params := [("#0"%pstring, "const C3&"%cpp_type)];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.Unknown;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C3::C3(const C3&&)"%cpp_name, None)
+     : name * option ObjValue
+     = ("C3::operator=(const C3&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "const C3&";
+               m_class := "C3";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "const C3&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C3::operator=(C3&&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "C3&";
+               m_class := "C3";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "C3&&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C4::C4()"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C4";
+               c_params := [];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.Unknown;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C4::~C4()"%cpp_name, None)
+     : name * option ObjValue
+     = ("C4::C4(const C4&)"%cpp_name,
+        Some
+          (Oconstructor
+             {|
+               c_class := "C4";
+               c_params := [("#0"%pstring, "const C4&"%cpp_type)];
+               c_cc := CC_C;
+               c_arity := Ar_Definite;
+               c_exception := exception_spec.Unknown;
+               c_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C4::C4(const C4&&)"%cpp_name, None)
+     : name * option ObjValue
+     = ("C4::operator=(const C4&)"%cpp_name,
+        Some
+          (Omethod
+             {|
+               m_return := "const C4&";
+               m_class := "C4";
+               m_this_qual := QM;
+               m_params := [("#0"%pstring, "const C4&"%cpp_type)];
+               m_cc := CC_C;
+               m_arity := Ar_Definite;
+               m_exception := exception_spec.Unknown;
+               m_body := Some Defaulted
+             |}))
+     : name * option ObjValue
+     = ("C4::operator=(C4&&)"%cpp_name, None)
+     : name * option ObjValue

--- a/rocq-skylabs-brick/tests/implicit_members.v
+++ b/rocq-skylabs-brick/tests/implicit_members.v
@@ -1,0 +1,42 @@
+Require Import skylabs.lang.cpp.parser.
+Require Import skylabs.lang.cpp.parser.plugin.cpp2v.
+
+#[duplicates(error)]
+cpp.prog source prog cpp:{{
+  struct C1 { };
+  struct C2 { C2() = default; };
+  struct C3 { C3() = delete; };
+  struct C4 { ~C4() = delete; };
+}}.
+
+Definition get (n : name) :=
+  (n , source.(symbols) !! n).
+
+Eval vm_compute in get "C1::C1()".
+Eval vm_compute in get "C1::~C1()".
+Eval vm_compute in get "C1::C1(const C1&)".
+Eval vm_compute in get "C1::C1(const C1&&)".
+Eval vm_compute in get "C1::operator=(const C1&)".
+Eval vm_compute in get "C1::operator=(C1&&)".
+
+
+Eval vm_compute in get "C2::C2()".
+Eval vm_compute in get "C2::~C2()".
+Eval vm_compute in get "C2::C2(const C2&)".
+Eval vm_compute in get "C2::C2(const C2&&)".
+Eval vm_compute in get "C2::operator=(const C2&)".
+Eval vm_compute in get "C2::operator=(C2&&)".
+
+Eval vm_compute in get "C3::C3()".
+Eval vm_compute in get "C3::~C3()".
+Eval vm_compute in get "C3::C3(const C3&)".
+Eval vm_compute in get "C3::C3(const C3&&)".
+Eval vm_compute in get "C3::operator=(const C3&)".
+Eval vm_compute in get "C3::operator=(C3&&)".
+
+Eval vm_compute in get "C4::C4()".
+Eval vm_compute in get "C4::~C4()".
+Eval vm_compute in get "C4::C4(const C4&)".
+Eval vm_compute in get "C4::C4(const C4&&)".
+Eval vm_compute in get "C4::operator=(const C4&)".
+Eval vm_compute in get "C4::operator=(C4&&)".

--- a/rocq-skylabs-brick/tests/sub_module_with_implicits.v
+++ b/rocq-skylabs-brick/tests/sub_module_with_implicits.v
@@ -1,0 +1,23 @@
+Require Import skylabs.lang.cpp.parser.
+Require Import skylabs.lang.cpp.parser.plugin.cpp2v.
+Require Import skylabs.lang.cpp.semantics.sub_module.
+
+#[duplicates(error)]
+cpp.prog header prog cpp:{{
+  struct C {
+  };
+}}.
+
+#[duplicates(error)]
+cpp.prog cpp prog cpp:{{
+  struct C {
+  };
+
+  void test() {
+    C c;
+  }
+}}.
+
+Example first_tu_sub_module_second_tu :
+  bool_decide (sub_module header cpp) = true.
+Proof. vm_compute. reflexivity. Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/dune
+++ b/rocq-skylabs-brick/theories/lang/cpp/dune
@@ -2,6 +2,7 @@
 (rocq.theory
  (name skylabs.lang.cpp)
  (package rocq-skylabs-brick)
+ (modules (:standard \ parser.plugin.cpp2v_template))
  (plugins rocq-skylabs-brick.plugin)
  (theories
   Stdlib
@@ -25,3 +26,13 @@
   Corelib elpi.apps.NES.elpi elpi.apps.derive elpi.apps.derive.elpi
   elpi.apps.locker.elpi
  ))
+
+(subdir parser/plugin
+ (rule
+  (target cpp2v.v)
+  (deps
+   cpp2v_template.v
+   (package rocq-skylabs-cpp2v))
+  (action
+   (with-stdout-to %{target}
+    (bash "checksum=$(sha1sum %{bin:cpp2v} | cut -d' ' -f 1); sed \"s/PLACEHOLDER/${checksum}/g\" cpp2v_template.v")))))

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/func.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/func.v
@@ -808,7 +808,7 @@ that implies [type_ptr].
   match ctor.(c_body) with
   | None => ERROR "wp_ctor: no body"
   | Some Defaulted => UNSUPPORTED "wp_ctor: defaulted constructors"
-  | Some (UserDefined ib) =>
+  | Some (UserDefined ib | CompilerProvided ib) =>
     let inits := ib.1 in
     let body := ib.2 in
     match args with
@@ -975,6 +975,7 @@ this resource will be consumed immediately.
         let* :=
           match body with
           | Defaulted => fun k : Kpred => |={top}=>?upd k Normal
+          | CompilerProvided body
           | UserDefined body => wp tu (Remp (Some thisp) None Tvoid) body
           end%I
         in
@@ -1040,13 +1041,13 @@ Section wp_dtor.
     iIntros "HQ". rewrite wp_dtor.unlock.
     repeat case_match; auto.
     all: iIntros "wp !>"; iRevert "wp".
-    1,3: iIntros ">wp !>"; iRevert "wp".
-    3,4: iApply wp_frame; [done|]; iIntros (?).
+    1,4: iIntros ">wp !>"; iRevert "wp".
+    all: try (iApply wp_frame; [done|]; iIntros (?)).
     all: iApply Kreturn_void_frame.
     all: iIntros "($ & wp)"; iRevert "wp".
-    2,4: iApply wpd_members_frame; [done|].
-    2,3: iApply wp_revert_identity_frame =>//.
-    2,3: iApply wpd_bases_frame; [done|].
+    all: try (iApply wpd_members_frame; [done|]).
+    all: try (iApply wp_revert_identity_frame =>//).
+    all: try (iApply wpd_bases_frame; [done|]).
     all: iIntros "HR R"; iMod ("HR" with "R") as "HR"; iIntros "!> !> % R".
     all: iApply "HQ".
     all: iApply ("HR" with "R").
@@ -1063,13 +1064,13 @@ Section wp_dtor.
   Proof.
     rewrite wp_dtor.unlock. repeat case_match; auto.
     all: iIntros "wp !>"; iRevert "wp".
-    1,3: rewrite -fupd_intro.
-    3,4: iApply wp_frame; [done|]; iIntros (?).
+    1,4: rewrite -fupd_intro.
+    all: try (iApply wp_frame; [done|]; iIntros (?)).
     all: iApply Kreturn_void_frame.
     all: iIntros "($ & wp)"; iRevert "wp".
-    2,4: iApply wpd_members_frame; [done|].
-    2,3: iApply wp_revert_identity_frame =>//.
-    2,3: iApply wpd_bases_frame; [done|].
+    all: try (iApply wpd_members_frame; [done|]).
+    all: try (iApply wp_revert_identity_frame =>//).
+    all: try (iApply wpd_bases_frame; [done|]).
     all: iIntros "HR R !>"; iSpecialize ("HR" with "R"); iIntros "!> % R".
     all: iApply ("HR" with "R").
   Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/func.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/func.v
@@ -442,11 +442,11 @@ Section wp_func.
     intros. rewrite wp_func.unlock. iIntros "HQ".
     case_match; last by auto.
     case_match; last by iApply wp_builtin_func_frame.
-    iApply bind_vars_frame; [done|]. iIntros (??) "wp !>"; iRevert "wp".
-    iApply wp_frame; [done|]. iIntros (?).
-    iApply Kcleanup_frame; [done|].
-    iApply Kreturn_frame. iIntros (?) "Q".
-    iApply ("HQ" with "Q").
+    all: iApply bind_vars_frame; [done|]; iIntros (??) "wp !>"; iRevert "wp".
+    all: iApply wp_frame; [done|]; iIntros (?).
+    all: iApply Kcleanup_frame; [done|].
+    all: iApply Kreturn_frame; iIntros (?) "Q".
+    all: iApply ("HQ" with "Q").
   Qed.
 
   (** Unsupported *)
@@ -480,7 +480,7 @@ parameters.
     (m : Method) (args : list ptr) (Q : ptr -> epred) : mpred :=
   match m.(m_body) with
   | None => ERROR "wp_method: no body"
-  | Some (UserDefined body) =>
+  | Some (UserDefined body | CompilerProvided body) =>
     match args with
     | thisp :: rest_vals =>
       let ρ va := Remp (Some thisp) va m.(m_return) in
@@ -509,12 +509,14 @@ Section wp_method.
     |-- wp_method tu m args Q -* wp_method tu' m args Q'.
   Proof.
     intros. iIntros "HQ". rewrite wp_method.unlock.
-    repeat case_match; auto.
-    iApply bind_vars_frame; [done|]. iIntros (??) "wp !>"; iRevert "wp".
-    iApply wp_frame; [done|]. iIntros (?).
-    iApply Kcleanup_frame; [done|].
-    iApply Kreturn_frame. iIntros (?) "Q".
-    iApply ("HQ" with "Q").
+    destruct m as [m_return m_class m_this_qual m_params m_cc m_arity m_exception m_body]; cbn.
+    destruct m_body as [[|body|body]|]; auto.
+    all: destruct args as [|thisp rest_vals]; auto.
+    all: iApply bind_vars_frame; [done|]; iIntros (??) "wp !>"; iRevert "wp".
+    all: iApply wp_frame; [done|]; iIntros (?).
+    all: iApply Kcleanup_frame; [done|].
+    all: iApply Kreturn_frame; iIntros (?) "Q".
+    all: iApply ("HQ" with "Q").
   Qed.
 
   (** Unsupported *)
@@ -526,11 +528,14 @@ Section wp_method.
   Lemma wp_method_intro tu m args Q :
     Cbn (Reduce (wp_method' false tu m args Q)) |-- wp_method tu m args Q.
   Proof.
-    rewrite wp_method.unlock. do 3!f_equiv.
-    iApply bind_vars_frame; [done|]. iIntros (??) "wp !>"; iRevert "wp".
-    iApply wp_frame; [done|]. iIntros (?).
-    iApply Kcleanup_frame; [done|].
-    iApply Kreturn_frame. auto.
+    rewrite wp_method.unlock.
+    destruct m as [m_return m_class m_this_qual m_params m_cc m_arity m_exception m_body]; cbn.
+    destruct m_body as [[|body|body]|]; auto.
+    all: destruct args as [|thisp rest_vals]; auto.
+    all: iApply bind_vars_frame; [done|]; iIntros (??) "wp !>"; iRevert "wp".
+    all: iApply wp_frame; [done|]; iIntros (?).
+    all: iApply Kcleanup_frame; [done|].
+    all: iApply Kreturn_frame; auto.
   Qed.
 
   Lemma wp_method_elim tu m args Q :

--- a/rocq-skylabs-brick/theories/lang/cpp/parser.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser.v
@@ -235,6 +235,73 @@ Definition Dglobal_using_namespace (alias : name) : K :=
 Definition Dstatic_assert (msg : option PrimString.string) (e : Expr) : K :=
   _skip.
 
+Definition Oimplicit_default_ctor (n : globname) : K :=
+  let ctor := Oconstructor
+                {| c_class := n
+                ; c_params := []
+                ; c_cc := CC_C
+                ; c_arity := Ar_Definite
+                ; c_exception := exception_spec.Unknown (* TODO: problematic? *)
+                ; c_body := Some Defaulted |} in
+  _symbols (Nscoped n $ Nctor []) ctor.
+
+
+Definition Oimplicit_copy_ctor (n : globname) (is_const : bool) : K :=
+  let arg := Tref $ if is_const then (Tconst (Tnamed n)) else Tnamed n in
+  let ctor := Oconstructor
+                {| c_class := n
+                ; c_params := [("#0"%pstring, arg)]
+                ; c_cc := CC_C
+                ; c_arity := Ar_Definite
+                ; c_exception := exception_spec.Unknown (* TODO: problematic? *)
+                ; c_body := Some Defaulted |} in
+  _symbols (Nscoped n $ Nctor [arg]) ctor.
+
+Definition Oimplicit_move_ctor (n : globname) (is_const : bool) : K :=
+  let arg := Trv_ref $ if is_const then (Tconst (Tnamed n)) else Tnamed n in
+  let ctor := Oconstructor
+                {| c_class := n
+                ; c_params := [("#0"%pstring, arg)]
+                ; c_cc := CC_C
+                ; c_arity := Ar_Definite
+                ; c_exception := exception_spec.Unknown (* TODO: problematic? *)
+                ; c_body := Some Defaulted |} in
+  _symbols (Nscoped n $ Nctor [arg]) ctor.
+
+Definition Oimplicit_copy_assign (n : globname) (is_const : bool) : K :=
+  let arg := Tref $ if is_const then (Tconst (Tnamed n)) else Tnamed n in
+  let ctor := Omethod
+                {| m_class := n
+                ; m_params := [("#0"%pstring, arg)]
+                ; m_return := arg
+                ; m_this_qual := QM
+                ; m_cc := CC_C
+                ; m_arity := Ar_Definite
+                ; m_exception := exception_spec.Unknown (* TODO: problematic? *)
+                ; m_body := Some Defaulted |} in
+  _symbols (Nscoped n $ Nop function_qualifiers.N OOEqual [arg]) ctor.
+
+Definition Oimplicit_move_assign (n : globname) : K :=
+  let arg := Tnamed n in
+  let ctor := Omethod
+                {| m_class := n
+                ; m_params := [("#0"%pstring, Trv_ref arg)]
+                ; m_return := Tref arg
+                ; m_this_qual := QM
+                ; m_cc := CC_C
+                ; m_arity := Ar_Definite
+                ; m_exception := exception_spec.Unknown (* TODO: problematic? *)
+                ; m_body := Some Defaulted |} in
+  _symbols (Nscoped n $ Nop function_qualifiers.N OOEqual [Trv_ref arg]) ctor.
+
+Definition Oimplicit_dtor (n : globname) : K :=
+  let dtor := Odestructor
+                {| d_class := n
+                ; d_cc := CC_C
+                ; d_exception := exception_spec.Unknown (* TODO: problematic? *)
+                ; d_body := Some Defaulted |} in
+  _symbols (Nscoped n $ Ndtor) dtor.
+
 Definition Qconst_volatile : type -> type := tqualified QCV.
 Definition Qconst : type -> type := tqualified QC.
 Definition Qvolatile : type -> type := tqualified QV.

--- a/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v.v
@@ -1,11 +1,12 @@
 (*
- * Copyright (c) 2025 BlueRock Security, Inc.
+ * Copyright (c) 2025-2026 SkyLabs AI, Inc.
  * This software is distributed under the terms of the BedRock Open-Source License.
  * See the LICENSE-BedRock file in the repository root for details.
  *)
 Require Stdlib.Array.PArray.
 Require Import Stdlib.Numbers.Cyclic.Int63.PrimInt63.
 Require Import skylabs.lang.cpp.parser.
+Require skylabs.lang.cpp.syntax.typed.
 
 #[local] Set Printing Universes.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v_template.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v_template.v
@@ -3,12 +3,16 @@
  * This software is distributed under the terms of the BedRock Open-Source License.
  * See the LICENSE-BedRock file in the repository root for details.
  *)
+Require Import Stdlib.Strings.String.
 Require Stdlib.Array.PArray.
 Require Import Stdlib.Numbers.Cyclic.Int63.PrimInt63.
 Require Import skylabs.lang.cpp.parser.
 Require skylabs.lang.cpp.syntax.typed.
 
+#[local] Open Scope string_scope.
 #[local] Set Printing Universes.
+
+Definition version : string := "PLACEHOLDER".
 
 Register translation_unit.t as skylabs.lang.cpp.parser.translation_unit.t.
 Register translation_unit._skip as skylabs.lang.cpp.parser.translation_unit.skip.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/sub_module.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/sub_module.v
@@ -224,6 +224,40 @@ Qed.
 
 (** ** Inclusion of [ObjValue] *)
 
+Definition OrDefault_le {T : Set} `{EqDecision T} (ae be : exception_spec.t) (a b : OrDefault T) : bool :=
+  match a , b with
+  | Defaulted , Defaulted => bool_decide (ae ⊆ be)
+  | Defaulted , CompilerProvided _ => bool_decide (ae ⊆ be)
+  | CompilerProvided x , CompilerProvided y
+  | UserDefined x , UserDefined y => bool_decide (ae = be /\ x = y)
+  | _ , _ => false
+  end.
+Definition OrDefault_ler {T : Set} `{EqDecision T} : relation (exception_spec.t * OrDefault T) :=
+  λ '(ae, a) '(be, b), OrDefault_le ae be a b = true.
+
+Section OrDefault_ler.
+  Context {T : Set} `{EqDecision T}.
+
+  #[local] Instance OrDefault_le_refl : Reflexive (@OrDefault_ler T _).
+  Proof.
+    rewrite /OrDefault_ler/OrDefault_le.
+    intros [? od]; destruct od => //=;
+      apply bool_decide_eq_true_2; done.
+  Qed.
+
+  #[local] Instance OrDefault_le_trans : Transitive (@OrDefault_ler T _).
+  Proof.
+    rewrite /OrDefault_ler/OrDefault_le.
+    intros [? x] [? y] [?z] Hxy Hyz.
+    repeat case_match; subst; try congruence.
+    all: repeat case_bool_decide; intuition (subst; try tauto).
+    { exfalso. apply H1. etrans; eauto. }
+    { exfalso. apply H1. etrans; eauto. }
+  Qed.
+
+  #[global] Instance: PreOrder (@OrDefault_ler T _) := {}.
+End OrDefault_ler.
+
 (** [ObjVal_le a b] holds when [a] has compatible (but possibly less)
     information than [b].
     For example, [a] might be a declaration while [b] is a compatible
@@ -270,7 +304,7 @@ Definition ObjValue_le (a b : ObjValue) : bool := Eval cbv beta iota zeta delta 
                    List.map (fun b => drop_norm b.2) m'.(m_params))
     | Some b , Some b' =>
       bool_decide (m.(m_params) = m'.(m_params)) &&
-      bool_decide (b = b')
+      OrDefault_le m.(m_exception) m'.(m_exception) b b'
     | _ , None => false
     end
   | Oconstructor c , Oconstructor c' =>
@@ -284,7 +318,7 @@ Definition ObjValue_le (a b : ObjValue) : bool := Eval cbv beta iota zeta delta 
     | _ , None => false
     | Some x , Some y =>
       bool_decide (c.(c_params) = c'.(c_params)) &&
-      bool_decide (x = y)
+      OrDefault_le c.(c_exception) c'.(c_exception) x y
     end
   | Odestructor dd , Odestructor dd' =>
     bool_decide (dd.(d_cc) = dd'.(d_cc)) &&
@@ -292,7 +326,7 @@ Definition ObjValue_le (a b : ObjValue) : bool := Eval cbv beta iota zeta delta 
     match dd.(d_body) , dd'.(d_body) with
     | None , _ => true
     | _ , None => false
-    | Some x , Some y => bool_decide (x = y)
+    | Some x , Some y => OrDefault_le dd.(d_exception) dd'.(d_exception) x y
     end
   | _ , _ => false
   end.
@@ -302,7 +336,7 @@ Arguments ObjValue_ler !_ _ /.
 Section ObjValue_ler.
   #[local] Instance ObjValue_le_refl : Reflexive ObjValue_ler.
   Proof.
-    rewrite /ObjValue_ler/ObjValue_le => ?; smash.
+    rewrite /ObjValue_ler/ObjValue_le/OrDefault_le => ?; smash.
   Qed.
 
   #[local] Instance ObjValue_le_trans : Transitive ObjValue_ler.
@@ -317,12 +351,14 @@ Section ObjValue_ler.
            | H : false = true |- _ => inversion H
            | H : true = false |- _ => inversion H
            | H : bool_decide _ = true |- _ => apply bool_decide_eq_true_1 in H; subst
+           | H : OrDefault_le ?xe ?ye ?x ?y = true |- _ => change (OrDefault_ler (xe,x) (ye,y)) in H
            | H : context [ if @bool_decide ?P ?DEC then _ else _ ] |- _ =>
                 destruct (@bool_decide_reflect P DEC); subst
            | H : match ?X with _ => _ end = _ |- _ => destruct X eqn:?
            | |- bool_decide _ = _ => apply bool_decide_eq_true_2
+           | |- OrDefault_le ?xe ?ye ?x ?y = true => change (OrDefault_ler (xe,x) (ye,y))
            | |- context [ bool_decide ?X ] => rewrite (bool_decide_eq_true_2 X); [ | by etrans; eauto ]
-           end; solve [ eauto | etrans; eauto ]).
+           end; try solve [ eauto | etrans; eauto ]).
   Qed.
 
   #[global] Instance: PreOrder ObjValue_ler := {}.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/decl.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/decl.v
@@ -17,6 +17,7 @@ Require Import skylabs.lang.cpp.syntax.stmt.
 
 Variant OrDefault {t : Set} : Set :=
   | Defaulted
+  | CompilerProvided (_ : t)
   | UserDefined (_ : t).
 Arguments OrDefault : clear implicits.
 #[global] Instance OrDefault_inh: forall {T: Set}, Inhabited (OrDefault T).
@@ -30,6 +31,7 @@ Module OrDefault.
   Definition fmap {A B : Set} (f : A -> B) (v : OrDefault A) : OrDefault B :=
     match v with
     | Defaulted => Defaulted
+    | CompilerProvided a => CompilerProvided $ f a
     | UserDefined a => UserDefined (f a)
     end.
   #[global] Arguments fmap _ _ _ & _ : assert.
@@ -51,6 +53,7 @@ Module OrDefault.
     fun F _ _ _ _ _ f od =>
       match od with
       | Defaulted => mret Defaulted
+      | CompilerProvided v => CompilerProvided <$> f v
       | UserDefined v => UserDefined <$> f v
       end.
 End OrDefault.
@@ -265,7 +268,7 @@ Definition static_method (m : Method)
    ; f_arity := m.(m_arity)
    ; f_exception := m.(m_exception)
    ; f_body := match m.(m_body) with
-               | Some (UserDefined body) => Some (Impl body)
+               | Some (UserDefined body | CompilerProvided body) => Some (Impl body)
                | _ => None
                end |}.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -222,7 +222,7 @@ Section with_monad.
   Definition check_exc_spec {B} (exc : _) (body : option (OrDefault B)) : M :=
     if exc is exception_spec.Unknown
     then match body with
-         | Some Defaulted => OK
+         | None | Some Defaulted => OK
          | _ => FAIL "unknown exception spec"
          end
     else OK.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -213,10 +213,20 @@ Section with_monad.
   Definition or_default {T : Set} (f : T -> M) (o : OrDefault T) : M :=
     match o with
     | Defaulted => OK
+    | CompilerProvided v => f v
     | UserDefined v => f v
     end.
 
   Definition classname : classname -> M := name.
+
+  Definition check_exc_spec {B} (exc : _) (body : option (OrDefault B)) : M :=
+    if exc is exception_spec.Unknown
+    then match body with
+         | Some Defaulted => OK
+         | _ => FAIL "unknown exception spec"
+         end
+    else OK.
+
 
   Definition obj_value (o : ObjValue) : M :=
     let params (ps : list (localname * core.type)) : M :=
@@ -236,33 +246,17 @@ Section with_monad.
         type m.(m_return) <+> classname m.(m_class)
         <+> params m.(m_params)
         <+> opt (or_default stmt) m.(m_body)
-        <+> if m.(m_exception) is exception_spec.Unknown
-            then match m.(m_body) with
-                 | None => OK
-                 | _ => FAIL "unknown exception spec"
-                 end
-            else OK
+        <+> check_exc_spec m.(m_exception) m.(m_body)
 
     | Oconstructor c =>
         let check_body '(li, s) := lst (expr ∘ init_init) li <+> stmt s in
         classname c.(c_class) <+> params c.(c_params)
         <+> opt (or_default check_body) c.(c_body)
-        <+> if c.(c_exception) is exception_spec.Unknown
-            then match c.(c_body) with
-                 | None => OK
-                 | _ => FAIL "unknown exception spec"
-                 end
-            else OK
+        <+> check_exc_spec c.(c_exception) c.(c_body)
 
     | Odestructor d =>
         classname d.(d_class) <+> opt (or_default stmt) d.(d_body)
-        <+> if d.(d_exception) is exception_spec.Unknown
-            then match d.(d_body) with
-                 | None => OK
-                 | _ => FAIL "unknown exception spec"
-                 end
-            else OK
-
+        <+> check_exc_spec d.(d_exception) d.(d_body)
     end.
 
   Definition glob_decl (gd : GlobDecl) : M :=

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -1027,7 +1027,7 @@ Module decltype.
 
     Definition check_method (m : Method) : Merr unit :=
       match m.(m_body) with
-      | Some (UserDefined s) =>
+      | Some (UserDefined s | CompilerProvided s) =>
           readerT.mk $ fun tu =>
           let this_type := tqualified m.(m_this_qual) $ classname_to_type m.(m_class) in
           const () <$> readerT.run (with_bindings {| _bindings := m.(m_params) |} $ check_stmt s) (tu, m.(m_return), Some this_type, [])
@@ -1036,7 +1036,7 @@ Module decltype.
 
     Definition check_ctor (c : Ctor) : Merr unit :=
       match c.(c_body) with
-      | Some (UserDefined (inits, body)) =>
+      | Some (UserDefined (inits, body) | CompilerProvided (inits, body)) =>
           readerT.mk $ fun tu =>
           readerT.run (with_bindings {| _bindings := c.(c_params) |} $
                          let* _ := traverse (T:=eta list) (fun init => of_expr init.(init_init)) inits in
@@ -1046,7 +1046,7 @@ Module decltype.
 
     Definition check_dtor (d : Dtor) : Merr unit :=
       match d.(d_body) with
-      | Some (UserDefined body) =>
+      | Some (UserDefined body | CompilerProvided body) =>
           readerT.mk $ fun tu =>
           readerT.run (const () <$> check_stmt body) (tu, Tvoid, Some (classname_to_type d.(d_class)), [])
       | _ => mret ()

--- a/rocq-skylabs-cpp2v/src/PrintDecl.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintDecl.cpp
@@ -630,6 +630,11 @@ static fmt::Formatter &printFunctionParams(CoqPrinter &print,
     });
 }
 
+static llvm::StringRef orDefaultBodyCtorName(const FunctionDecl &decl) {
+    return decl.isImplicit() || decl.isDefaulted() ? "CompilerProvided"
+                                                   : "UserDefined";
+}
+
 static fmt::Formatter &printFunction(CoqPrinter &print,
                                      const FunctionDecl &decl,
                                      ClangPrinter &cprint, const ASTContext &) {
@@ -675,9 +680,9 @@ static fmt::Formatter &printMethod(CoqPrinter &print, const CXXMethodDecl &decl,
     cprint.printExceptionSpec(print, decl) << fmt::nbsp;
     if (auto body = decl.getBody()) {
         guard::some some(print);
-        guard::ctor _(print, "UserDefined");
+        guard::ctor _(print, orDefaultBodyCtorName(decl));
         return cprint.printStmt(print, body);
-    } else if (decl.isDefaulted()) {
+    } else if (decl.isDefaulted() || isImplicitSpecialMethod(decl)) {
         return print.output() << "(Some Defaulted)";
     } else {
         return print.none();
@@ -775,10 +780,12 @@ static fmt::Formatter &printConstructor(CoqPrinter &print,
     cprint.printExceptionSpec(print, decl) << fmt::nbsp;
     if (auto body = decl.getBody()) {
         guard::some s(print);
-        guard::ctor ud(print, "UserDefined");
+        guard::ctor od(print, orDefaultBodyCtorName(decl));
         guard::tuple _(print);
         printInitializerList(print, decl, cprint) << fmt::tuple_sep;
         return cprint.printStmt(print, body);
+    } else if (decl.isDefaulted() || isImplicitSpecialMethod(decl)) {
+        return print.output() << "(Some Defaulted)";
     } else {
         return print.none();
     }
@@ -797,9 +804,9 @@ static fmt::Formatter &printDestructor(CoqPrinter &print,
     cprint.printExceptionSpec(print, decl) << fmt::nbsp;
     if (auto body = decl.getBody()) {
         guard::some some(print);
-        guard::ctor _(print, "UserDefined");
+        guard::ctor _(print, orDefaultBodyCtorName(decl));
         return cprint.printStmt(print, body);
-    } else if (decl.isDefaulted()) {
+    } else if (decl.isDefaulted() || isImplicitSpecialMethod(decl)) {
         return print.output() << "(Some Defaulted)";
     } else {
         return print.none();
@@ -1112,20 +1119,105 @@ public:
         return printType(Dstruct, *decl, print, cprint, ctxt);
     }
 
+    bool printImplicitMembers(const CXXRecordDecl &decl, CoqPrinter &print,
+                              ClangPrinter &cprint, const ASTContext &ctxt) {
+        if (ClangPrinter::debug && cprint.trace(Trace::Decl))
+            cprint.trace("printImplicitMembers", loc::of(decl));
+
+        if (decl.isDependentContext())
+            return false;
+
+        auto findCtor = [&](auto pred) -> const CXXConstructorDecl * {
+            for (auto ctor : decl.ctors()) {
+                if (ctor && ctor->isImplicit() && pred(*ctor))
+                    return ctor;
+            }
+            return nullptr;
+        };
+
+        auto findMethod = [&](auto pred) -> const CXXMethodDecl * {
+            for (auto method : decl.methods()) {
+                if (method && method->isImplicit() && pred(*method))
+                    return method;
+            }
+            return nullptr;
+        };
+
+        const auto *default_ctor = findCtor([](const CXXConstructorDecl &ctor) {
+            return ctor.isDefaultConstructor();
+        });
+        const auto *copy_ctor = findCtor([](const CXXConstructorDecl &ctor) {
+            return ctor.isCopyConstructor();
+        });
+        const auto *move_ctor = findCtor([](const CXXConstructorDecl &ctor) {
+            return ctor.isMoveConstructor();
+        });
+        const auto *copy_assign = findMethod([](const CXXMethodDecl &method) {
+            return method.isCopyAssignmentOperator();
+        });
+        const auto *move_assign = findMethod([](const CXXMethodDecl &method) {
+            return method.isMoveAssignmentOperator();
+        });
+        const auto *dtor = decl.getDestructor();
+
+        bool printed = false;
+
+        if (!default_ctor && decl.needsImplicitDefaultConstructor()) {
+            guard::ctor _{print, "Oimplicit_default_ctor"};
+            cprint.printName(print, decl);
+            printed = true;
+        }
+        if (!copy_ctor && decl.needsImplicitCopyConstructor() &&
+            !decl.hasUserDeclaredCopyAssignment()) {
+            guard::ctor _{print, "Oimplicit_copy_ctor"};
+            cprint.printName(print, decl) << fmt::nbsp;
+            print.boolean(decl.hasCopyConstructorWithConstParam());
+            printed = true;
+        }
+        if (!move_ctor && decl.needsImplicitMoveConstructor()) {
+            guard::ctor _{print, "Oimplicit_move_ctor"};
+            cprint.printName(print, decl) << fmt::nbsp;
+            print.boolean(false);
+            printed = true;
+        }
+        if (!copy_assign && decl.needsImplicitCopyAssignment() &&
+            !decl.hasUserDeclaredCopyConstructor()) {
+            guard::ctor _{print, "Oimplicit_copy_assign"};
+            cprint.printName(print, decl) << fmt::nbsp;
+            print.boolean(decl.hasCopyAssignmentWithConstParam());
+            printed = true;
+        }
+        if (!move_assign && decl.needsImplicitMoveAssignment()) {
+            guard::ctor _{print, "Oimplicit_move_assign"};
+            cprint.printName(print, decl);
+            printed = true;
+        }
+        if (!dtor && decl.needsImplicitDestructor()) {
+            guard::ctor _{print, "Oimplicit_dtor"};
+            cprint.printName(print, decl);
+            printed = true;
+        }
+        return printed;
+    }
+
     bool VisitCXXRecordDecl(const CXXRecordDecl *decl, CoqPrinter &print,
                             ClangPrinter &cprint, const ASTContext &ctxt) {
         if (ClangPrinter::debug && cprint.trace(Trace::Decl))
             cprint.trace("VisitCXXRecordDecl", loc::of(decl));
+        bool printed = false;
+        if (decl->isCompleteDefinition()) {
+            printed = printImplicitMembers(*decl, print, cprint, ctxt);
+        }
         if (decl->isStruct() or decl->isClass()) {
-            return VisitStructDecl(decl, print, cprint, ctxt);
+            return VisitStructDecl(decl, print, cprint, ctxt) || printed;
         } else if (decl->isUnion()) {
-            return VisitUnionDecl(decl, print, cprint, ctxt);
+            return VisitUnionDecl(decl, print, cprint, ctxt) || printed;
         } else {
             std::string msg;
             llvm::raw_string_ostream os{msg};
             os << "CXXRecord with tag kind " << decl->getKindName();
             unsupported(cprint, loc::of(decl), msg);
-            return false;
+            return printed;
         }
     }
 

--- a/rocq-skylabs-cpp2v/src/ToCoq.cpp
+++ b/rocq-skylabs-cpp2v/src/ToCoq.cpp
@@ -280,9 +280,9 @@ void ToCoqConsumer::toCoqModule(clang::ASTContext *ctxt,
                 print.output()
                     << fmt::line << "Require skylabs.lang.cpp.syntax.typed."
                     << fmt::line
-                    << "Succeed Example well_typed : "
-                       "typed.decltype.check_tu module = trace.Success tt"
-                       " := ltac:(vm_compute; reflexivity)."
+                    << "Succeed Example well_typed : typed.decltype.check_tu "
+                    << interactive_.value_or("source")
+                    << " = trace.Success tt := ltac:(vm_compute; reflexivity)."
                     << fmt::line;
             }
         });


### PR DESCRIPTION
This is more robust than doing this in C++, but it isn't possible to get exception specifications in general because they will be inherited from bases which ultimately could use other features.

That said, these exception specifications should be computable by recursion on the type heirarchy, it just isn't something that we'd like to setup.