### PR TITLE
Ensure that [cpp.prog] does not have side-effects

### DIFF
--- a/rocq-skylabs-brick/tests/cpp_prog_inline.t/run.t
+++ b/rocq-skylabs-brick/tests/cpp_prog_inline.t/run.t
@@ -2,10 +2,14 @@
 
 Compiling the Coq test file.
   $ dune build 2>&1 | sed -E -e 's!([ .]|^)/[^ :"]*!\1<path>!g'
+  length
+       : forall A : Type, list A -> nat
   source1
-       : translation_unit
+       : translation_unit.translation_unit
   source2
-       : translation_unit
+       : translation_unit.translation_unit
+  @length
+       : forall A : Type, list A -> nat
 
 
 

--- a/rocq-skylabs-brick/tests/cpp_prog_inline.t/test.v
+++ b/rocq-skylabs-brick/tests/cpp_prog_inline.t/test.v
@@ -1,4 +1,5 @@
-Require Import skylabs.lang.cpp.parser.
+Check @length.
+
 Require Import skylabs.lang.cpp.parser.plugin.cpp2v.
 
 #[duplicates(warn)]
@@ -31,3 +32,6 @@ cpp.prog source3 prog cpp:{{
   }
 }}.
 End code.
+
+(* check that the interpretation of [length] does not change *)
+Check @length.

--- a/rocq-skylabs-brick/tests/dealias.t/main_cpp.v
+++ b/rocq-skylabs-brick/tests/dealias.t/main_cpp.v
@@ -15,6 +15,7 @@ cpp.prog source prog cpp:{{
 }}.
 
 Require Import skylabs.lang.cpp.syntax.dealias.
+Require Import skylabs.lang.cpp.cpp.
 
 Notation TEST input output :=
   (eq_refl : trace.runO (resolveValue source input%cpp_name) = Some output%cpp_name).

--- a/rocq-skylabs-brick/tests/name_resolution.t/test.v
+++ b/rocq-skylabs-brick/tests/name_resolution.t/test.v
@@ -29,7 +29,7 @@ cpp.prog source prog cpp:{{
     bar<const C&&>(c);
   }
 }}.
-
+Require Import skylabs.lang.cpp.cpp.
 Require Import skylabs.lang.cpp.syntax.dealias.
 
 Notation TEST input output :=

--- a/rocq-skylabs-cpp2v/src/ToCoq.cpp
+++ b/rocq-skylabs-cpp2v/src/ToCoq.cpp
@@ -141,11 +141,11 @@ void ToCoqConsumer::toCoqModule(clang::ASTContext *ctxt,
             CoqPrinter print(fmt, /*templates*/ false, cache);
             ClangPrinter cprint(compiler_, ctxt, trace_, comment_, typedefs_);
 
-            parser(print);
             if (interactive_.has_value()) {
                 print.output() << "Section cpp_prog__" << interactive_.value()
                                << "__." << fmt::line;
             }
+            parser(print);
             bytestring(print) << fmt::line;
 
             if (this->sharing_) {
@@ -221,7 +221,7 @@ void ToCoqConsumer::toCoqModule(clang::ASTContext *ctxt,
             print.output() << "." << fmt::outdent << fmt::outdent << fmt::line;
 
             // Close the section if we opened one
-            if (this->interactive_.has_value()) {
+            if (interactive_.has_value()) {
                 print.output() << "End cpp_prog__" << interactive_.value()
                                << "__." << fmt::line;
             }


### PR DESCRIPTION
Before this change, `cpp.prog ...` would `Import` files which would affect the meaning of constants, e.g. `length`.