### PR TITLE
Fix semantics: reading nullptr_t must use `wp_discard`

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
@@ -792,12 +792,12 @@ Module Type Expr.
     Axiom wp_operand_cast_null : forall e ty Q,
         type_of e = Tnullptr ->
         is_pointer ty ->
-            wp_operand e Q (* note: [has_type v Tnullptr |-- has_type v (Tptr ty)] *)
+            wp_discard e (Q (Vptr nullptr)) (* note: [has_type v Tnullptr |-- has_type v (Tptr ty)] *)
         |-- wp_operand (Ecast (Cnull2ptr ty) e) Q.
 
     Axiom wp_operand_cast_null2memberptr : forall cls e ty Q,
         type_of e = Tnullptr ->
-            wp_operand e (fun _ free => Q (Vmember_ptr cls None) free)
+            wp_discard e (Q (Vmember_ptr cls None))
         |-- wp_operand (Ecast (Cnull2memberptr $ Tmember_pointer (Tnamed cls) ty) e) Q.
 
     (* Determine if a 0-constant of this type can be used as a pseudonym for <<nullptr>> *)
@@ -818,8 +818,8 @@ Module Type Expr.
     Axiom wp_operand_cast_null_int : forall e ty Q,
         can_represent_null (type_of e) ->
         is_pointer ty ->
-            (letI* v, free := wp_operand e in
-             [| v = Vint 0 |] ** Q (Vptr nullptr) free)
+            (letI* free := wp_discard e in
+             Q (Vptr nullptr) free)
         |-- wp_operand (Ecast (Cnull2ptr ty) e) Q.
 
     (* note(gmm): in the clang AST, the subexpression is the call.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
@@ -790,13 +790,13 @@ Module Type Expr.
         |-- wp_operand (Ecast (Cintegral t) e) Q.
 
     Axiom wp_operand_cast_null : forall e ty Q,
-        type_of e = Tnullptr ->
+        drop_qualifiers (type_of e) = Tnullptr ->
         is_pointer ty ->
             wp_discard e (Q (Vptr nullptr)) (* note: [has_type v Tnullptr |-- has_type v (Tptr ty)] *)
         |-- wp_operand (Ecast (Cnull2ptr ty) e) Q.
 
     Axiom wp_operand_cast_null2memberptr : forall cls e ty Q,
-        type_of e = Tnullptr ->
+        drop_qualifiers (type_of e) = Tnullptr ->
             wp_discard e (Q (Vmember_ptr cls None))
         |-- wp_operand (Ecast (Cnull2memberptr $ Tmember_pointer (Tnamed cls) ty) e) Q.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
@@ -790,13 +790,11 @@ Module Type Expr.
         |-- wp_operand (Ecast (Cintegral t) e) Q.
 
     Axiom wp_operand_cast_null : forall e ty Q,
-        drop_qualifiers (type_of e) = Tnullptr ->
         is_pointer ty ->
             wp_discard e (Q (Vptr nullptr)) (* note: [has_type v Tnullptr |-- has_type v (Tptr ty)] *)
         |-- wp_operand (Ecast (Cnull2ptr ty) e) Q.
 
     Axiom wp_operand_cast_null2memberptr : forall cls e ty Q,
-        drop_qualifiers (type_of e) = Tnullptr ->
             wp_discard e (Q (Vmember_ptr cls None))
         |-- wp_operand (Ecast (Cnull2memberptr $ Tmember_pointer (Tnamed cls) ty) e) Q.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
@@ -367,6 +367,17 @@ Arguments eval_le _ {_}.
 Arguments eval_gt _ {_}.
 Arguments eval_ge _ {_}.
 
+(* Special cases for <decltype(nullptr)> because they are not generally comparable *)
+Axiom eval_eq_nullptr :
+  forall rty,
+  relop_result_type rty ->
+  eval_binop_pure Beq Tnullptr Tnullptr rty (Vptr PTRS_INTF_AXIOM.nullptr) (Vptr PTRS_INTF_AXIOM.nullptr) (Vbool true).
+Axiom eval_neq_nullptr :
+  forall rty,
+  relop_result_type rty ->
+  eval_binop_pure Bneq Tnullptr Tnullptr rty (Vptr PTRS_INTF_AXIOM.nullptr) (Vptr PTRS_INTF_AXIOM.nullptr) (Vbool false).
+
+
 End operator_axioms.
 End OPERATOR_INTF_FUNCTOR.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -473,7 +473,7 @@ Module decltype.
         | Cint2bool => mret Tbool
         | Cnull2ptr t =>
             let* _ :=
-              match (to_exprtype base).2 with
+              match drop_qualifiers (to_exprtype base).2 with
               | Tnullptr | Tnum _ _ => mret tt
               | _ => throw ("source of null2ptr cast must be nullptr or integral type"%bs, base)
               end

--- a/rocq-skylabs-cpp2v/tests/nullptr.t/Makefile
+++ b/rocq-skylabs-cpp2v/tests/nullptr.t/Makefile
@@ -1,0 +1,22 @@
+CPPFLAGS = -std=c++17
+
+CPP_FILES = $(shell find . -name '*.cpp')
+HPP_FILES = $(shell find . -name '*.hpp')
+
+GEN_FILES = \
+  $(CPP_FILES:.cpp=_cpp.v) $(CPP_FILES:.cpp=_cpp_names.v) \
+  $(HPP_FILES:.hpp=_hpp.v) $(HPP_FILES:.hpp=_hpp_names.v)
+
+Q = @
+
+all: $(GEN_FILES) $(GEN_VALCAT_FILES)
+
+%_cpp.v: %.cpp
+	$(Q)cpp2v -v -o $@ $< --check-types -- $(CPPFLAGS)
+%_hpp.v: %.hpp
+	$(Q)cpp2v -v -o $@ $< --check-types -- $(CPPFLAGS)
+
+%_cpp_names.v: %.cpp
+	$(Q)cpp2v -v -names $@ $< --check-types -- $(CPPFLAGS)
+%_hpp_names.v: %.hpp
+	$(Q)cpp2v -v -names $@ $< --check-types -- $(CPPFLAGS)

--- a/rocq-skylabs-cpp2v/tests/nullptr.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/nullptr.t/run.t
@@ -1,0 +1,11 @@
+  $ . ../setup-project.sh
+
+Compiling the C++ code, use "make Q=" for debugging.
+  $ make 2> /dev/null
+  $ ls *.v | wc -l | sed -e 's/ //g'
+  3
+
+Compiling the generated Coq files.
+  $ dune build
+       = nil
+       : check.M

--- a/rocq-skylabs-cpp2v/tests/nullptr.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/nullptr.t/test.cpp
@@ -1,0 +1,34 @@
+extern void assert(bool);
+#define CHECK_NULL(expr) assert((expr) == nullptr)
+
+struct NullptrHolder {
+  decltype(nullptr) value;
+};
+
+void coverage_nullptr_local_direct_reads() {
+  decltype(nullptr) local = nullptr;
+  CHECK_NULL(local);
+}
+
+void coverage_nullptr_local_reference_reads() {
+  decltype(nullptr) local = nullptr;
+  decltype(nullptr)& npr = local;
+  CHECK_NULL(npr);
+
+  const decltype(nullptr)& cnpr = local;
+  CHECK_NULL(cnpr);
+}
+
+void coverage_nullptr_field_direct_reads() {
+  NullptrHolder holder{nullptr};
+  CHECK_NULL(holder.value);
+}
+
+void coverage_nullptr_field_reference_reads() {
+  NullptrHolder holder{nullptr};
+  decltype(nullptr)& npr = holder.value;
+  CHECK_NULL(npr);
+
+  const decltype(nullptr)& cnpr = holder.value;
+  CHECK_NULL(cnpr);
+}

--- a/rocq-skylabs-cpp2v/tests/nullptr.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/nullptr.t/test.v
@@ -1,0 +1,5 @@
+Require Import skylabs.lang.cpp.syntax.supported.
+
+Require test.test_cpp.
+
+Eval vm_compute in supported.check.translation_unit test_cpp.module.


### PR DESCRIPTION
These are not common, but we ascribe the wrong semantics to them.