### PR TITLE
Hide warning about flags and paths

### DIFF
--- a/rocq-skylabs-brick/plugin/src/cpp2v.ml
+++ b/rocq-skylabs-brick/plugin/src/cpp2v.ml
@@ -169,9 +169,11 @@ let cpp_command_prog (attrs : report_level option * bool) name flags prog =
       match flags with
       | None -> []
       | Some flags ->
+        (*
         Feedback.msg_notice Pp.(str "Note that cpp.prog does not guarantee the working directory," ++ Pp.brk (0,0) ++
                                 str "so relative paths may yield inconsistent results between different editors." ++ fnl () ++
                                str "Current working directory: " ++ str (Unix.getcwd ())) ;
+                               *)
         Str.split (Str.regexp "[ \n\r\x0c\t]+") flags
     in
     ["cpp2v";


### PR DESCRIPTION
Right now we get a constant spurious warning for every use of `cpp.prog flags...`. The whole source code gets an annoying squiggly that interferes with reading.

We could have an opt-in flag to hide it, so users have to confirm the warning's spurious for their case. But I'm not sure it's worth it.