### PR TITLE
Template operators

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
@@ -254,6 +254,10 @@ Definition Eunresolved_member (arrow : bool) (base : MExpr) (i : Mname) : MExpr 
   else
     Eunresolved_member base i.
 
+(** TODO: Add this as a constructor. *)
+Definition Eunresolved_delete (array : bool) (arg : MExpr) : MExpr :=
+  Eunsupported "unresolved delete" Tvoid.
+
 (** ** Template-only derived variable declarations emitted by cpp2v *)
 
 Definition Einitializing_type (t : Mdecltype) (e : MExpr) : MExpr :=

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
@@ -256,7 +256,7 @@ Definition Eunresolved_member (arrow : bool) (base : MExpr) (i : Mname) : MExpr 
 
 (** ** Template-only derived variable declarations emitted by cpp2v *)
 
-#[local] Definition set_declared_type (t : Mdecltype) (e : MExpr) : MExpr :=
+Definition Einitializing_type (t : Mdecltype) (e : MExpr) : MExpr :=
   match e with
   | Eunresolved_parenlist None es => Eunresolved_parenlist (Some t) es
   | Eunresolved_initlist None es => Eunresolved_initlist (Some t) es

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
@@ -259,6 +259,7 @@ Definition Eunresolved_member (arrow : bool) (base : MExpr) (i : Mname) : MExpr 
 #[local] Definition set_declared_type (t : Mdecltype) (e : MExpr) : MExpr :=
   match e with
   | Eunresolved_parenlist None es => Eunresolved_parenlist (Some t) es
+  | Eunresolved_initlist None es => Eunresolved_initlist (Some t) es
   (**
   TODO: The same treatment for other direct initiailization
   expressions.

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
@@ -78,6 +78,9 @@ Module BinOp.
     | Rassign => Eassign
     | Rassign_op op => Eassign_op op
     | Rsubscript => Esubscript
+    | Rcomma => fun l r _ => Ecomma l r
+    | Rand => fun l r _ => Eseqand l r
+    | Ror => fun l r _ => Eseqor l r
     end.
 
   (** The type of binary operators emitted by cpp2v *)
@@ -177,6 +180,13 @@ Definition Esubscript : BinOp.t :=
   BinOp.infer_subscript.
 Definition Ebinop (op : BinOp) : BinOp.t :=
   BinOp.infer (Rbinop op) $ BinOp.resolve_binop op.
+Definition Ecomma := fun l r =>
+  if BinOp.is_unresolved $ type_of l then Eunresolved_binop Rcomma l r else Ecomma l r.
+Definition Eseqand := fun l r =>
+  if BinOp.is_unresolved $ type_of l then Eunresolved_binop Rand l r else Eseqand l r.
+Definition Eseqor := fun l r =>
+  if BinOp.is_unresolved $ type_of l then Eunresolved_binop Ror l r else Eseqor l r.
+
 
 Module UnOp.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/stmt.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/stmt.v
@@ -5,21 +5,11 @@
  *)
 
 Require Import skylabs.lang.cpp.mparser.prelude.
+Require Import skylabs.lang.cpp.mparser.expr.
 Require Export skylabs.lang.cpp.parser.stmt.
 Require Import skylabs.lang.cpp.syntax.typing.
 
 (** ** Template-only derived variable declarations emitted by cpp2v *)
 
-#[local] Definition set_declared_type (t : Mdecltype) (e : MExpr) : MExpr :=
-  match e with
-  | Eunresolved_parenlist None es => Eunresolved_parenlist (Some t) es
-  | Eunresolved_initlist None es => Eunresolved_initlist (Some t) es
-  (**
-  TODO: The same treatment for other direct initialization
-  expressions.
-  *)
-  | _ => e
-  end.
-
 Definition Dvar (name : localname) (t : Mdecltype) (init : option MExpr) : MVarDecl :=
-  Dvar name t (set_declared_type t <$> init).
+  Dvar name t (Einitializing_type t <$> init).

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/stmt.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/stmt.v
@@ -13,6 +13,7 @@ Require Import skylabs.lang.cpp.syntax.typing.
 #[local] Definition set_declared_type (t : Mdecltype) (e : MExpr) : MExpr :=
   match e with
   | Eunresolved_parenlist None es => Eunresolved_parenlist (Some t) es
+  | Eunresolved_initlist None es => Eunresolved_initlist (Some t) es
   (**
   TODO: The same treatment for other direct initialization
   expressions.
@@ -22,4 +23,3 @@ Require Import skylabs.lang.cpp.syntax.typing.
 
 Definition Dvar (name : localname) (t : Mdecltype) (init : option MExpr) : MVarDecl :=
   Dvar name t (set_declared_type t <$> init).
-

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/tu.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/tu.v
@@ -87,6 +87,9 @@ Definition Ddestructor (ps : Mtemp_params) (n : Mname) (f : MDtor) : K :=
 Definition Dtype (ps : Mtemp_params) (n : Mname) : K :=
   _types <[n := Template ps Gtype]>.
 
+Definition Dunsupported (n : Mname) (msg : PrimString.string) : K :=
+  _types <[n := Template [] $ Gunsupported msg]>.
+
 Definition Dstruct (ps : Mtemp_params) (n : Mname) (f : option MStruct) : K :=
   _types <[n := Template ps $ if f is Some f then Gstruct f else Gtype]>.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -339,6 +339,9 @@ Module RBinOp.
     | Rassign => compare_tag Rassign
     | Rassign_op op => compare_ctor (Rassign_op op)
     | Rsubscript => compare_tag Rsubscript
+    | Rcomma => compare_tag Rcomma
+    | Rand => compare_tag Rand
+    | Ror => compare_tag Ror
     end.
 
 End RBinOp.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -591,32 +591,41 @@ Module temp_param.
       match p with
       | Ptype _ => 1
       | Pvalue _ _ => 2
-      | Punsupported _ => 3
+      | Ptemplate _ _ => 3
+      | Punsupported _ => 4
       end.
     Definition car (t : positive) : Set :=
       match t with
       | 2 => box_Pvalue
+      | 3 => ident * list temp_param
       | _ => ident
       end.
     Definition data (p : temp_param) : car (tag p) :=
       match p with
       | Ptype id => id
       | Pvalue id t => Box_Pvalue id t
+      | Ptemplate id ps => (id, ps)
       | Punsupported msg => msg
       end.
-    Definition compare_data (t : positive) : car t -> car t -> comparison :=
+    Definition compare_data (tp_compare : temp_param -> temp_param -> comparison)
+      (t : positive) : car t -> car t -> comparison :=
       match t with
       | 2 => box_Pvalue_compare
+      | 3 =>
+          fun '(id1, ps1) '(id2, ps2) =>
+            compare_lex (PrimString.compare id1 id2) $ fun _ =>
+            List.compare tp_compare ps1 ps2
       | _ => PrimString.compare
       end.
 
-    #[local] Notation compare_ctor := (compare_ctor tag car data compare_data).
+    #[local] Notation compare_ctor compare := (compare_ctor tag car data $ compare_data compare).
 
-    Definition compare (p : temp_param_ type) : temp_param_ type -> comparison :=
+    Fixpoint compare (p : temp_param_ type) : temp_param_ type -> comparison :=
       match p with
-      | Ptype id => compare_ctor (Reduce (tag (Ptype id))) (fun _ => Reduce (data (Ptype id)))
-      | Pvalue id ty => compare_ctor (Reduce (tag (Pvalue id ty))) (fun _ => Reduce (data (Pvalue id ty)))
-      | Punsupported msg => compare_ctor (Reduce (tag (Punsupported msg))) (fun _ => Reduce (data (Punsupported msg)))
+      | Ptype id => compare_ctor compare (Reduce (tag (Ptype id))) (fun _ => Reduce (data (Ptype id)))
+      | Pvalue id ty => compare_ctor compare (Reduce (tag (Pvalue id ty))) (fun _ => Reduce (data (Pvalue id ty)))
+      | Ptemplate id ps => compare_ctor compare (Reduce (tag (Ptemplate id ps))) (fun _ => Reduce (data (Ptemplate id ps)))
+      | Punsupported msg => compare_ctor compare (Reduce (tag (Punsupported msg))) (fun _ => Reduce (data (Punsupported msg)))
       end.
   End compare.
 
@@ -635,7 +644,8 @@ Module temp_arg.
       | Avalue _ => 2
       | Apack _ => 3
       | Atemplate _ => 4
-      | Aunsupported _ => 5
+      | Atemplate_param _ => 5
+      | Aunsupported _ => 6
       end.
     Definition car (t : positive) : Set :=
       match t with
@@ -651,6 +661,7 @@ Module temp_arg.
       | Avalue e => e
       | Apack ls => ls
       | Atemplate n => n
+      | Atemplate_param id => id
       | Aunsupported msg => msg
       end.
     Definition compare_data (ta_compare : temp_arg -> temp_arg -> comparison)
@@ -671,6 +682,7 @@ Module temp_arg.
       | Avalue e => compare_ctor compare (Reduce (tag (Avalue e))) (fun _ => Reduce (data (Avalue e)))
       | Apack ls => compare_ctor compare (Reduce (tag (Apack ls))) (fun _ => Reduce (data (Apack ls)))
       | Atemplate n => compare_ctor compare (Reduce (tag (Atemplate n))) (fun _ => Reduce (data (Atemplate n)))
+      | Atemplate_param id => compare_ctor compare (Reduce (tag (Atemplate_param id))) (fun _ => Reduce (data (Atemplate_param id)))
       | Aunsupported msg => compare_ctor compare (Reduce (tag (Aunsupported msg))) (fun _ => Reduce (data (Aunsupported msg)))
       end.
   End compare.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -1420,6 +1420,14 @@ Module Expr.
       compare_lex (option.compare compareT b1.(box_Eunresolved_parenlist_0) b2.(box_Eunresolved_parenlist_0)) $ fun _ =>
       List.compare compareE b1.(box_Eunresolved_parenlist_1) b2.(box_Eunresolved_parenlist_1).
 
+    Record box_Eunresolved_initlist : Set := Box_Eunresolved_initlist {
+      box_Eunresolved_initlist_0 : option type;
+      box_Eunresolved_initlist_1 : list Expr;
+    }.
+    Definition box_Eunresolved_initlist_compare (b1 b2 : box_Eunresolved_initlist) : comparison :=
+      compare_lex (option.compare compareT b1.(box_Eunresolved_initlist_0) b2.(box_Eunresolved_initlist_0)) $ fun _ =>
+      List.compare compareE b1.(box_Eunresolved_initlist_1) b2.(box_Eunresolved_initlist_1).
+
     Record box_Eunresolved_member : Set := Box_Eunresolved_member {
       box_Eunresolved_member_0 : Expr;
       box_Eunresolved_member_1 : name;
@@ -1801,6 +1809,7 @@ Module Expr.
       | Eunresolved_call _ _ => 5
       | Eunresolved_member_call _ _ _ => 6
       | Eunresolved_parenlist _ _ => 7
+      | Eunresolved_initlist _ _ => 65
       | Eunresolved_member _ _ => 8
       | Evar _ _ => 9
       | Eenum_const _ _ => 10
@@ -1918,6 +1927,7 @@ Module Expr.
       | 62 => box_Emember_ignore
       | 63 => box_Efloat
       | 64 => type
+      | 65 => box_Eunresolved_initlist
       | _ => box_Eunsupported
       end.
     Definition data (e : Expr) : car (tag e) :=
@@ -1929,6 +1939,7 @@ Module Expr.
       | Eunresolved_call on es => Box_Eunresolved_call on es
       | Eunresolved_member_call on e es => Box_Eunresolved_member_call on e es
       | Eunresolved_parenlist e es => Box_Eunresolved_parenlist e es
+      | Eunresolved_initlist e es => Box_Eunresolved_initlist e es
       | Eunresolved_member e f => Box_Eunresolved_member e f
       | Eexplicit_cast s t e => Box_Eexplicit_cast s t e
       | Evar n t => Box_Evar n t
@@ -2046,6 +2057,7 @@ Module Expr.
       | 62 => box_Emember_ignore_compare
       | 63 => box_Efloat_compare
       | 64 => compareT
+      | 65 => box_Eunresolved_initlist_compare
       | _ => box_Eunsupported_compare
       end.
 
@@ -2064,6 +2076,7 @@ Module Expr.
       | Eunresolved_call on es => COMP (Eunresolved_call on es)
       | Eunresolved_member_call on e es => COMP (Eunresolved_member_call on e es)
       | Eunresolved_parenlist e es => COMP (Eunresolved_parenlist e es)
+      | Eunresolved_initlist e es => COMP (Eunresolved_initlist e es)
       | Eunresolved_member e f => COMP (Eunresolved_member e f)
       | Eexplicit_cast s e t => COMP (Eexplicit_cast s e t)
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -2479,3 +2479,5 @@ End compare_instances.
   LeibnizComparison.from_comparison.
 #[global] Instance temp_arg_eq_dec : EqDecision temp_arg :=
   LeibnizComparison.from_comparison.
+#[global] Instance temp_param_eq_dec : EqDecision temp_param :=
+  LeibnizComparison.from_comparison.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -630,7 +630,14 @@ Module temp_param.
   End compare.
 
 End temp_param.
-#[global] Instance temp_param_compare {A : Set} `{!Compare A} : Compare (temp_param_ A) := temp_param.compare compare.
+#[global] Instance temp_param_compare {A : Set} `{!Compare A} : Compare (temp_param_ A) :=
+  temp_param.compare compare.
+#[global] Instance temp_param_comparison {A : Set} `{!@Comparison A cmpA}
+  : Comparison (temp_param.compare cmpA).
+Proof. Admitted.
+#[global] Instance temp_param_leibniz_comparison {A : Set} `{!@Comparison A cmpA} `{LeibnizComparison cmpA}
+  : LeibnizComparison (temp_param.compare cmpA).
+Proof. Admitted.
 
 Module temp_arg.
   Section compare.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -1807,6 +1807,7 @@ Module Expr.
       | Eglobal _ _ => 11
       | Echar _ _ => 12
       | Estring _ _ => 13
+      | Eunresolved_string_literal _ => 64
       | Eint _ _ => 14
       | Ebool _ => 15
       | Eunop _ _ _ => 16
@@ -1916,6 +1917,7 @@ Module Expr.
       | 61 => box_Elambda
       | 62 => box_Emember_ignore
       | 63 => box_Efloat
+      | 64 => type
       | _ => box_Eunsupported
       end.
     Definition data (e : Expr) : car (tag e) :=
@@ -1935,6 +1937,7 @@ Module Expr.
       | Eglobal_member on t => Box_Eglobal on t
       | Echar c t => Box_Echar c t
       | Estring s t => Box_Estring s t
+      | Eunresolved_string_literal t => t
       | Eint n t => Box_Eint n t
       | Ebool b => b
       | Efloat ft v => Box_Efloat ft (float_value.to_bits ft v)
@@ -2042,6 +2045,7 @@ Module Expr.
       | 61 => box_Elambda_compare
       | 62 => box_Emember_ignore_compare
       | 63 => box_Efloat_compare
+      | 64 => compareT
       | _ => box_Eunsupported_compare
       end.
 
@@ -2071,6 +2075,7 @@ Module Expr.
 
       | Echar c t => COMP (Echar c t)
       | Estring s t => COMP (Estring s t)
+      | Eunresolved_string_literal t => COMP (Eunresolved_string_literal t)
       | Eint n t => COMP (Eint n t)
 
       | Ebool b => COMP (Ebool b : Expr)

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -453,6 +453,7 @@ var(arg1,…,argN)>> with dependent type <<T>>. Making the type optional
 simplifies cpp2v---we set it from context in ../mparser.v.
 *)
 | Eunresolved_parenlist (_ : option type) (_ : list Expr)
+| Eunresolved_initlist (_ : option type) (_ : list Expr)
 | Eunresolved_member (_ : Expr) (_ : name)
 
 (**
@@ -951,6 +952,7 @@ with is_dependentE (e : Expr) : bool :=
   | Eunresolved_call _ _
   | Eunresolved_member_call _ _ _
   | Eunresolved_parenlist _ _
+  | Eunresolved_initlist _ _
   | Eunresolved_member _ _ => true
   | Evar _ t => is_dependentT t
   | Eenum_const n _ => is_dependentN n

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -475,6 +475,7 @@ program because, in part, C++ has no type for references to members.
 
 | Echar (c : N) (t : type)
 | Estring (s : literal_string.t) (t : type)
+| Eunresolved_string_literal (t : type)
 | Eint (n : Z) (t : type)
 | Ebool (b : bool)
 | Efloat (ft : float_type.t) (_ : float_type.car ft)
@@ -957,6 +958,7 @@ with is_dependentE (e : Expr) : bool :=
   | Eglobal_member n t => is_dependentN n || is_dependentT t
   | Echar _ t
   | Estring _ t
+  | Eunresolved_string_literal t
   | Eint _ t => is_dependentT t
   | Ebool _
   | Efloat _ _ => false

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -80,23 +80,6 @@ Inductive temp_param_ {type : Set} : Set :=
 #[global] Arguments temp_param_ : clear implicits.
 #[global] Instance temp_param__inhabited {A} : Inhabited (temp_param_ A).
 Proof. solve_inhabited. Qed.
-#[global] Instance temp_param_eq_dec {A : Set} `{!EqDecision A} : EqDecision (temp_param_ A).
-Proof.
-  change (forall x y : temp_param_ A, Decision (x = y)).
-  fix IH 1.
-  intros x y.
-  unfold Decision.
-  destruct x as [i|i t|i ps|msg], y as [j|j u|j qs|msg'];
-    try (right; congruence).
-  - destruct (decide (i = j)) as [->|?]; [left; reflexivity|right; congruence].
-  - destruct (decide (i = j)) as [->|?];
-      destruct (decide (t = u)) as [->|?];
-      try (left; reflexivity); right; congruence.
-  - destruct (decide (i = j)) as [->|?];
-      destruct (@list_eq_dec _ IH ps qs) as [->|?];
-      try (left; reflexivity); right; congruence.
-  - destruct (decide (msg = msg')) as [->|?]; [left; reflexivity|right; congruence].
-Defined.
 
 Module temp_param.
   Import UPoly.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -67,29 +67,53 @@ End function_type.
 (** Template parameters
     - <<typename T>> would be represented as [Ptype "T"]
     - <<int X>> would be represented as [Pvalue "X" Tint]
+    - <<template <typename T> class C>> would be represented as
+      [Ptemplate "C" [Ptype "T"]]
 
     <<typename T...>> and <<int X...>> are not currently supported.
  *)
-Variant temp_param_ {type : Set} : Set :=
+Inductive temp_param_ {type : Set} : Set :=
 | Ptype (_ : ident)
 | Pvalue (_ : ident) (_ : type)
+| Ptemplate (_ : ident) (_ : list temp_param_)
 | Punsupported (_ : PrimString.string).
 #[global] Arguments temp_param_ : clear implicits.
 #[global] Instance temp_param__inhabited {A} : Inhabited (temp_param_ A).
 Proof. solve_inhabited. Qed.
 #[global] Instance temp_param_eq_dec {A : Set} `{!EqDecision A} : EqDecision (temp_param_ A).
-Proof. solve_decision. Defined.
+Proof.
+  change (forall x y : temp_param_ A, Decision (x = y)).
+  fix IH 1.
+  intros x y.
+  unfold Decision.
+  destruct x as [i|i t|i ps|msg], y as [j|j u|j qs|msg'];
+    try (right; congruence).
+  - destruct (decide (i = j)) as [->|?]; [left; reflexivity|right; congruence].
+  - destruct (decide (i = j)) as [->|?];
+      destruct (decide (t = u)) as [->|?];
+      try (left; reflexivity); right; congruence.
+  - destruct (decide (i = j)) as [->|?];
+      destruct (@list_eq_dec _ IH ps qs) as [->|?];
+      try (left; reflexivity); right; congruence.
+  - destruct (decide (msg = msg')) as [->|?]; [left; reflexivity|right; congruence].
+Defined.
 
 Module temp_param.
   Import UPoly.
-  Definition existsb {type : Set} (f : type -> bool) (p : temp_param_ type) : bool :=
-    if p is Pvalue _ t then f t else false.
+  Fixpoint existsb {type : Set} (f : type -> bool) (p : temp_param_ type) : bool :=
+    match p with
+    | Ptype _ => false
+    | Pvalue _ t => f t
+    | Ptemplate _ ps => List.existsb (existsb f) ps
+    | Punsupported _ => false
+    end.
 
-  Definition fmap {type type' : Set} (f : type -> type')
+  Fixpoint fmap {type type' : Set} (f : type -> type')
     (p : temp_param_ type) : temp_param_ type' :=
     match p with
     | Ptype id => Ptype id
     | Pvalue id t => Pvalue id (f t)
+    | Ptemplate id ps => Ptemplate id (List.map (fmap f) ps)
     | Punsupported msg => Punsupported msg
     end.
   #[global] Arguments fmap _ _ _ & _ : assert.
@@ -103,11 +127,13 @@ Module temp_param.
     Context {F : Set -> Type@{u}} `{!FMap F, !MRet F, AP : !Ap F}.
     Context {type type' : Set}.
 
-    Definition traverse (f : type -> F type') (p : temp_param_ type)
+    Fixpoint traverse (f : type -> F type') (p : temp_param_ type)
       : F (temp_param_ type') :=
       match p with
       | Ptype id => mret $ Ptype id
       | Pvalue id t => Pvalue id <$> f t
+      | Ptemplate id ps =>
+          Ptemplate id <$> UPoly.traverse (T:=eta list) (F:=F) (traverse f) ps
       | Punsupported msg => mret $ Punsupported msg
       end.
     #[global] Arguments traverse _ & _ : assert.
@@ -347,12 +373,15 @@ Inductive name : Set :=
       C++ requires these to be uniform, i.e. you can not mix [Avalue] and [Atype].
       We can enforce this if we want in the future.
     - <<T>> for <<T>> of template type would be represented as [Atemplate T]
+    - <<T>> for <<T>> of template-template parameter would be represented
+      as [Atemplate_param "T"]
  *)
 with temp_arg : Set :=
 | Atype (_ : type)
 | Avalue (_ : Expr)
 | Apack (_ : list temp_arg) (* See <https://en.cppreference.com/w/cpp/language/pack> *)
 | Atemplate (_ : name)
+| Atemplate_param (_ : ident)
 | Aunsupported (_ : PrimString.string)
 
 (** ** Types *)
@@ -873,6 +902,7 @@ with is_dependentTA (t : temp_arg) : bool :=
   | Avalue e => is_dependentE e
   | Apack tas => List.existsb is_dependentTA tas
   | Atemplate nm => is_dependentN nm
+  | Atemplate_param _ => false
   | Aunsupported _ => false
   end
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/handler.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/handler.v
@@ -70,6 +70,8 @@ Record expr_handler'@{u} {N T E : Set} {F : Set -> Type@{u}} : Type@{u} := {
     (_ : unit -> F N) (_ : unit -> F E) (_ : unit -> list (F E)) : F E;
   handle_Eunresolved_parenlist (_ : option type) (_ : list Expr)
     (_ : unit -> option (F T)) (_ : unit -> list (F E)) : F E;
+  handle_Eunresolved_initlist (_ : option type) (_ : list Expr)
+    (_ : unit -> option (F T)) (_ : unit -> list (F E)) : F E;
   handle_Eunresolved_member (_ : Expr) (_ : name) (_ : unit -> F E) (_ : unit -> F N) : F E;
   (** Embedded expression types *)
   handle_expr_type : F T -> F T;
@@ -137,6 +139,7 @@ Section handlers.
     handle_Eunresolved_call _ _ n es := Eunresolved_call <$> n () <*> sequence@{eta list} (es ());
     handle_Eunresolved_member_call _ _ _ n e es := Eunresolved_member_call <$> n () <*> e () <*> sequence@{eta list} (es ());
     handle_Eunresolved_parenlist _ _ t es := Eunresolved_parenlist <$> sequence@{eta option} (t ()) <*> sequence@{eta list} (es ());
+    handle_Eunresolved_initlist _ _ t es := Eunresolved_initlist <$> sequence@{eta option} (t ()) <*> sequence@{eta list} (es ());
     handle_Eunresolved_member _ _ o f := Eunresolved_member <$> o () <*> f ();
     handle_expr_type := id;
     handle_Eunresolved_cast _ Mt _ Me := (fun t e => Ecast (Cdependent t) e) <$> Mt () <*> Me () ;

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
@@ -229,6 +229,7 @@ Module MTraverse.
 
       | Echar c t => Echar c <$> ET (traverseT t)
       | Estring s t => Estring s <$> ET (traverseT t)
+      | Eunresolved_string_literal t => Eunresolved_string_literal <$> ET (traverseT t)
       | Eint z t => Eint z <$> ET (traverseT t)
       | Ebool b => mret $ Ebool b
       | Efloat ft v => mret $ Efloat ft v

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
@@ -216,6 +216,7 @@ Module MTraverse.
       | Eunresolved_call on es => hE.(handle_Eunresolved_call) on es (fun _ => traverseN on) (fun _ => traverseE <$> es)
       | Eunresolved_member_call on e es => hE.(handle_Eunresolved_member_call) on e es (fun _ => traverseN on) (fun _ => traverseE e) (fun _ => traverseE <$> es)
       | Eunresolved_parenlist t es => hE.(handle_Eunresolved_parenlist) t es (fun _ => traverseT <$> t) (fun _ => traverseE <$> es)
+      | Eunresolved_initlist t es => hE.(handle_Eunresolved_initlist) t es (fun _ => traverseT <$> t) (fun _ => traverseE <$> es)
       | Eunresolved_member e f => hE.(handle_Eunresolved_member) e f (fun _ => traverseE e) (fun _ => traverseN f)
 
       (**

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
@@ -159,6 +159,7 @@ Module MTraverse.
       | Avalue e => Avalue <$> traverseE e
       | Apack ls => Apack <$> UPoly.traverse (T:=eta list) (F:=F) traverseTA ls
       | Atemplate n => Atemplate <$> traverseN n
+      | Atemplate_param id => mret $ Atemplate_param id
       | Aunsupported msg => mret $ Aunsupported msg
       end
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
@@ -140,6 +140,9 @@ Section with_lang.
     | overloadable.Rassign => mret "="
     | overloadable.Rassign_op b => (fun a => a ++ "=") <$> printBO b
     | overloadable.Rsubscript => mret "[]"
+    | overloadable.Rcomma => mret ","
+    | overloadable.Rand => mret "&&"
+    | overloadable.Ror => mret "||"
     end.
 
   Fixpoint printN (inst : PrimString.string) (nm : name) : option PrimString.string :=
@@ -316,6 +319,7 @@ Module Type TESTS.
     TEST "Msg<unsigned long, long, unsigned long long, long long, unsigned int, int>::Msg()" (Nscoped (Ninst Msg targs) (Nctor [])) := eq_refl.
   Succeed Example _0 : TEST "Msg::Msg(int)" (Nscoped Msg (Nctor [Tint])) := eq_refl.
   Succeed Example _0 : TEST "operator|(int, int)" (Nglobal (Nop function_qualifiers.N OOPipe [Tint;Tint])) := eq_refl.
+  Succeed Example _0 : TEST "operator||(int, int)" (Nglobal (Nop function_qualifiers.N OOPipePipe [Tint;Tint])) := eq_refl.
   Succeed Example _0 : TEST "Msg::Msg(long)" (Nscoped Msg (Nctor [Tlong])) := eq_refl.
   Succeed Example _0 : TEST "Msg::operator=(const Msg&)" (Nscoped Msg (Nop function_qualifiers.N OOEqual [Tref (Tconst (Tnamed $ Nglobal (Nid "Msg")))])) := eq_refl.
   Succeed Example _0 : TEST "Msg::operator=(const Msg&&)" (Nscoped Msg (Nop function_qualifiers.N OOEqual [Trv_ref (Tconst (Tnamed $ Nglobal (Nid "Msg")))])) := eq_refl.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
@@ -160,6 +160,8 @@ Section with_lang.
               ((fun tas => "..." ++ (angles $ sepBy ", " tas)) <$> traverse printTA ts)
           | Atemplate nm =>
               (fun b => "template " ++ b) <$> printN "" nm
+          | Atemplate_param id =>
+              mret $ "template " ++ id
           | Aunsupported note => mfail
           end
         in

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
@@ -114,7 +114,7 @@ Section with_lang.
     let printBO o :=
       match o with
       | Badd => mret "+"
-      | Band => mret "&&"
+      | Band => mret "&"
       | Bcmp => mret "<=>"
       | Bdiv => mret "/"
       | Beq => mret "=="
@@ -124,7 +124,7 @@ Section with_lang.
       | Blt => mret "<"
       | Bmul => mret "*"
       | Bneq => mret "!="
-      | Bor => mret "||"
+      | Bor => mret "|"
       | Bmod => mret "%"
       | Bshl => mret "<<"
       | Bshr => mret ">>"
@@ -315,6 +315,7 @@ Module Type TESTS.
                             Tuint; Tint] in
     TEST "Msg<unsigned long, long, unsigned long long, long long, unsigned int, int>::Msg()" (Nscoped (Ninst Msg targs) (Nctor [])) := eq_refl.
   Succeed Example _0 : TEST "Msg::Msg(int)" (Nscoped Msg (Nctor [Tint])) := eq_refl.
+  Succeed Example _0 : TEST "operator|(int, int)" (Nglobal (Nop function_qualifiers.N OOPipe [Tint;Tint])) := eq_refl.
   Succeed Example _0 : TEST "Msg::Msg(long)" (Nscoped Msg (Nctor [Tlong])) := eq_refl.
   Succeed Example _0 : TEST "Msg::operator=(const Msg&)" (Nscoped Msg (Nop function_qualifiers.N OOEqual [Tref (Tconst (Tnamed $ Nglobal (Nid "Msg")))])) := eq_refl.
   Succeed Example _0 : TEST "Msg::operator=(const Msg&&)" (Nscoped Msg (Nop function_qualifiers.N OOEqual [Trv_ref (Tconst (Tnamed $ Nglobal (Nid "Msg")))])) := eq_refl.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/namemap.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/namemap.v
@@ -14,9 +14,6 @@ Require Import skylabs.lang.cpp.syntax.compare.
 
 (** ** Name maps *)
 
-#[global] Declare Instance name_comparison :
-  Comparison (compareN).	(** TODO *)
-
 Module Import internal.
 
   Module NameMap.
@@ -46,3 +43,27 @@ End NM.
 Module TM.
   Include NameMap.
 End TM.
+
+Module TPMap.
+  (* Map over [temp_param] *)
+
+  (* TODO: the need for this suggests some oddity in the setup of the
+     [Compare] and [Comparison] typeclasses. *)
+  #[local] Hint Transparent base.compare : typeclass_instances.
+
+  Module Compare.
+    Definition t : Type := temp_param.
+    #[local] Definition compare : t -> t -> comparison := temp_param_compare.
+    #[local] Infix "?=" := compare.
+    #[local] Lemma compare_sym x y : (y ?= x) = CompOpp (x ?= y).
+    Proof. exact: compare_antisym. Qed.
+    #[local] Lemma compare_trans c x y z : (x ?= y) = c -> (y ?= z) = c -> (x ?= z) = c.
+    Proof. exact: compare_trans. Qed.
+  End Compare.
+  Module Key := OrderedType_from_Alt Compare.
+  Lemma eqL : forall a b, Key.eq a b -> @eq _ a b.
+  Proof. apply LeibnizComparison.cmp_eq; refine _. Qed.
+  Include FMapAVL.Make Key.
+  Include FMapExtra.MIXIN Key.
+  Include FMapExtra.MIXIN_LEIBNIZ Key.
+End TPMap.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/overloadable.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/overloadable.v
@@ -56,6 +56,9 @@ Variant RBinOp : Set :=
 | Rassign
 | Rassign_op (op : BinOp)
 | Rsubscript
+| Rcomma
+| Rand
+| Ror
 .
 #[global] Instance RBinOp_eq_ec : EqDecision RBinOp.
 Proof. solve_decision. Defined.
@@ -69,12 +72,18 @@ Section countable.
       | Rassign => GenNode 1 []
       | Rassign_op op => GenNode 2 [OP op]
       | Rsubscript => GenNode 3 []
+      | Rcomma => GenNode 4 []
+      | Rand => GenNode 5 []
+      | Ror => GenNode 6 []
       end) (fun t =>
       match t with
       | GenNode 0 [OP op] => Rbinop op
       | GenNode 1 [] => Rassign
       | GenNode 2 [OP op] => Rassign_op op
       | GenNode 3 [] => Rsubscript
+      | GenNode 4 [] => Rcomma
+      | GenNode 5 [] => Rand
+      | GenNode 6 [] => Ror
       | _ => Rassign	(* dummy *)
       end)).
     abstract (by intros []).

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
@@ -167,6 +167,9 @@ Section with_lang.
     | overloadable.Rassign => "="
     | overloadable.Rassign_op b => printBO b ++ "="
     | overloadable.Rsubscript => "[]"
+    | overloadable.Rcomma => ","
+    | overloadable.Ror => "||"
+    | overloadable.Rand => "&&"
     end.
 
   Fixpoint printN (nm : name) : PrimString.string :=

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
@@ -141,7 +141,7 @@ Section with_lang.
     let printBO o :=
       match o with
       | Badd => "+"
-      | Band => "&&"
+      | Band => "&"
       | Bcmp => "<=>"
       | Bdiv => "/"
       | Beq => "=="
@@ -151,7 +151,7 @@ Section with_lang.
       | Blt => "<"
       | Bmul => "*"
       | Bneq => "!="
-      | Bor => "||"
+      | Bor => "|"
       | Bmod => "%"
       | Bshl => "<<"
       | Bshr => ">>"

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
@@ -189,6 +189,7 @@ Section with_lang.
       | Avalue e => [printE e]
       | Apack ls => List.concat (List.map printTA ls)
       | Atemplate n => ["<>" ++ printN n]
+      | Atemplate_param id => ["<>" ++ id]
       | Aunsupported note => [note]
       end
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -154,6 +154,7 @@ Section with_monad.
     | Eunresolved_call n es => name n <+> lst expr es
     | Eunresolved_member_call _ _ _
     | Eunresolved_parenlist _ _
+    | Eunresolved_initlist _ _
     | Eunresolved_member _ _ => OK
     | Earrayloop_init _ e _ _ e2 t => expr e <+> expr e2 <+> type t
     | Earrayloop_index _ t => type t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -98,9 +98,9 @@ Section with_monad.
     | Evar _ t => type t
     | Eenum_const n _ => name n
     | Eglobal n t | Eglobal_member n t => name n <+> type t
-    | Echar _ t | Estring _ t | Eint _ t => type t
-    | Ebool _
-    | Efloat _ _ => OK
+    | Echar _ t | Estring _ t | Eunresolved_string_literal t | Eint _ t => type t
+    | Efloat _ _
+    | Ebool _ => OK
     | Eunop _ e t => expr e <+> type t
     | Ebinop _ e1 e2 t => expr e1 <+> type t
     | Ederef e t => expr e <+> type t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -44,16 +44,18 @@ Section with_monad.
       | Avalue e => expr e
       | Apack xs => lst temp_arg xs
       | Atemplate n => name n
+      | Atemplate_param _ => OK
       | Aunsupported msg => FAIL msg
       end.
   End temp_arg.
 
   Section temp_param.
     Context (name : name -> M) (type : type -> M) (expr : Expr -> M).
-    Definition temp_param  (a : temp_param) : M :=
+    Fixpoint temp_param  (a : temp_param) : M :=
       match a with
       | Ptype _ => OK
       | Pvalue _ t => type t
+      | Ptemplate _ ps => lst temp_param ps
       | Punsupported msg => FAIL msg
       end.
   End temp_param.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -573,6 +573,8 @@ Module decltype.
             end
         | Estring chars t =>
             mret $ Tref $ Tarray (Tconst t) (1 + literal_string.lengthN chars)
+        | Eunresolved_string_literal t =>
+            mret $ Tref $ Tincomplete_array (Tconst t)
         | Eint _ t =>
             let* _ := guard (t ∈ [Tchar;Tuchar;Tschar;Tshort;Tushort;Tint;Tuint;Tlong;Tulong;Tlonglong;Tulonglong]) in
             mret t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -535,7 +535,7 @@ Module decltype.
         | Eunresolved_binop o l r => Tresult_binop o <$> of_expr l <*> of_expr r
         | Eunresolved_call on es => Tresult_call on <$> traverse (T:=eta list) of_expr es
         | Eunresolved_member_call on obj es => Tresult_member_call on <$> of_expr obj <*> traverse (T:=eta list) of_expr es
-        | Eunresolved_parenlist (Some t) es => Tresult_parenlist t <$> traverse (T:=eta list) of_expr es
+        | Eunresolved_parenlist (Some t) es => mret t (* Tresult_parenlist t <$> traverse (T:=eta list) of_expr es *)
         | Eunresolved_parenlist None _ => mfail
         | Eunresolved_member obj fld => Tresult_member <$> of_expr obj <*> mret fld
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -541,6 +541,8 @@ Module decltype.
         | Eunresolved_member_call on obj es => Tresult_member_call on <$> of_expr obj <*> traverse (T:=eta list) of_expr es
         | Eunresolved_parenlist (Some t) es => mret t (* Tresult_parenlist t <$> traverse (T:=eta list) of_expr es *)
         | Eunresolved_parenlist None _ => mfail
+        | Eunresolved_initlist (Some t) es => mret t (* Tresult_parenlist t <$> traverse (T:=eta list) of_expr es (* TODO: this is a bit awkward, do we need [Tresult_parenlist] at all? isn't it always going to be the type? *) *)
+        | Eunresolved_initlist None _ => mfail
         | Eunresolved_member obj fld => Tresult_member <$> of_expr obj <*> mret fld
 
         | Evar ln t =>
@@ -871,6 +873,8 @@ Module decltype.
         end
         in
         let* _ :=
+          (* NOTE: this is a consistency check between "shallow typing" (implemented in <typing.v>)
+             and "deep typing" (implemented here) *)
           match decltype.of_expr e with
           | None =>
               throw ("shallow failed to typecheck (term, expected)"%bs, e, result)

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -330,6 +330,10 @@ Module decltype.
         in
         trace (Can_initialize dt t) $
           match drop_qualifiers dt , drop_qualifiers t with
+          | Tauto , _ =>
+              (* Anything can initialize <auto>.
+                 TODO: make this only apply when checking template code *)
+              mret ()
           | Tref dt , Tref t
           | Trv_ref dt , Trv_ref t =>
               ref_conv dt t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
@@ -274,7 +274,7 @@ Module decltype.
         | Eunresolved_binop o l r => Tresult_binop o <$> of_expr l <*> of_expr r
         | Eunresolved_call on es => Tresult_call on <$> traverse_list of_expr es
         | Eunresolved_member_call on obj es => Tresult_member_call on <$> of_expr obj <*> traverse_list of_expr es
-        | Eunresolved_parenlist (Some t) es => Tresult_parenlist t <$> traverse_list of_expr es
+        | Eunresolved_parenlist (Some t) es => mret t (* Tresult_parenlist t <$> traverse_list of_expr es *)
         | Eunresolved_parenlist None _ => mfail
         | Eunresolved_member obj fld => Tresult_member <$> of_expr obj <*> mret fld
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
@@ -290,6 +290,8 @@ Module decltype.
         | Echar _ t => mret t
         | Estring chars t =>
             mret $ Tref $ Tarray (Tconst t) (1 + literal_string.lengthN chars)
+        | Eunresolved_string_literal t =>
+            mret $ Tref $ Tincomplete_array (Tconst t)
         | Eint _ t => mret t
         | Ebool _ => mret Tbool
         | Efloat ft _ => mret $ Tfloat_ ft

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
@@ -276,6 +276,8 @@ Module decltype.
         | Eunresolved_member_call on obj es => Tresult_member_call on <$> of_expr obj <*> traverse_list of_expr es
         | Eunresolved_parenlist (Some t) es => mret t (* Tresult_parenlist t <$> traverse_list of_expr es *)
         | Eunresolved_parenlist None _ => mfail
+        | Eunresolved_initlist (Some t) es => mret t (* Tresult_parenlist t <$> traverse_list of_expr es *)
+        | Eunresolved_initlist None _ => mfail
         | Eunresolved_member obj fld => Tresult_member <$> of_expr obj <*> mret fld
 
         | Evar _ t => mret $ tref QM t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/untemp.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/untemp.v
@@ -44,6 +44,7 @@ Module Import internal.
       handle_Eunresolved_call _ _ _ _ := mthrow Not_representable;
       handle_Eunresolved_member_call _ _ _ _ _ _ := mthrow Not_representable;
       handle_Eunresolved_parenlist _ _ _ _ := mthrow Not_representable;
+      handle_Eunresolved_initlist _ _ _ _ := mthrow Not_representable;
       handle_Eunresolved_member _ _ _ _ := mthrow Not_representable;
       handle_expr_type := id;
       handle_Eunresolved_cast _ _ _ _ := mthrow Not_representable;

--- a/rocq-skylabs-cpp2v/.gitignore
+++ b/rocq-skylabs-cpp2v/.gitignore
@@ -1,1 +1,2 @@
 build/
+/compile_commands.json

--- a/rocq-skylabs-cpp2v/dune
+++ b/rocq-skylabs-cpp2v/dune
@@ -49,7 +49,7 @@
      (run sed "s/ /\\n/g")))))
 
  (rule
-  (targets cpp2v dune.log)
+  (targets cpp2v dune.log compile_commands.json)
   (deps
    ; This code depends on the LLVM library, to try rebuilding `cpp2v` if LLVM
    ; is upgraded.
@@ -84,4 +84,22 @@
   (files cpp2v)
   (package rocq-skylabs-cpp2v)))
 
-(alias (name cpp2v) (deps rocq-skylabs-cpp2v.install))
+(rule
+ (target compile_commands.json)
+ (deps build-dune/compile_commands.json)
+ (mode promote)
+ (package rocq-skylabs-cpp2v)
+ (action
+  (with-stdout-to %{target}
+   (run sed
+    "-e"
+    "s#/_build/default/fmdeps/BRiCk/rocq-skylabs-cpp2v#/fmdeps/BRiCk/rocq-skylabs-cpp2v#g"
+    "-e"
+    "s#\"directory\": \"\\([^\"]*\\)/build-dune\"#\"directory\": \"\\1\"#g"
+    %{dep:build-dune/compile_commands.json}))))
+
+(alias
+ (name cpp2v)
+ (deps
+  rocq-skylabs-cpp2v.install
+  compile_commands.json))

--- a/rocq-skylabs-cpp2v/src/ClangPrinter.cpp
+++ b/rocq-skylabs-cpp2v/src/ClangPrinter.cpp
@@ -143,7 +143,6 @@ fmt::Formatter &ClangPrinter::printTemplateParam(CoqPrinter &print,
                     if (tpd->getDepth() != depth)
                         continue;
                     if (tpd->getIndex() == index) {
-                        always_assert(print.templates());
                         guard::ctor _{print, "Tparam", false};
                         print.str(tpd->getName());
                         return true;

--- a/rocq-skylabs-cpp2v/src/PrintDecl.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintDecl.cpp
@@ -751,7 +751,18 @@ static fmt::Formatter &printInitializer(const CXXConstructorDecl &ctor,
         fatal(cprint, loc::of(ctor), "initializer without expression");
     guard::ctor _(print, "Build_Initializer");
     printInitPath(ctor, init, print, cprint) << fmt::nbsp;
-    return cprint.printExpr(print, e);
+    if (print.templates()) {
+        guard::ctor _{print, "Einitializing_type"};
+        if (auto fd = init.getAnyMember()) {
+            cprint.printQualType(print, fd->getType(), loc::of(ctor));
+        } else if (auto bc = init.getBaseClass()) {
+            cprint.printType(print, *bc, loc::of(ctor));
+        }
+        print.output() << fmt::nbsp;
+        return cprint.printExpr(print, e);
+    } else {
+        return cprint.printExpr(print, e);
+    }
 }
 
 static fmt::Formatter &printInitializerList(CoqPrinter &print,

--- a/rocq-skylabs-cpp2v/src/PrintDecl.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintDecl.cpp
@@ -1161,41 +1161,46 @@ public:
         const auto *dtor = decl.getDestructor();
 
         bool printed = false;
+        auto nextImplicit = [&] {
+            if (printed && print.templates())
+                print.cons();
+            printed = true;
+        };
 
         if (!default_ctor && decl.needsImplicitDefaultConstructor()) {
+            nextImplicit();
             guard::ctor _{print, "Oimplicit_default_ctor"};
             cprint.printName(print, decl);
-            printed = true;
         }
         if (!copy_ctor && decl.needsImplicitCopyConstructor() &&
             !decl.hasUserDeclaredCopyAssignment()) {
+            nextImplicit();
             guard::ctor _{print, "Oimplicit_copy_ctor"};
             cprint.printName(print, decl) << fmt::nbsp;
             print.boolean(decl.hasCopyConstructorWithConstParam());
-            printed = true;
         }
         if (!move_ctor && decl.needsImplicitMoveConstructor()) {
+            nextImplicit();
             guard::ctor _{print, "Oimplicit_move_ctor"};
             cprint.printName(print, decl) << fmt::nbsp;
             print.boolean(false);
-            printed = true;
         }
         if (!copy_assign && decl.needsImplicitCopyAssignment() &&
             !decl.hasUserDeclaredCopyConstructor()) {
+            nextImplicit();
             guard::ctor _{print, "Oimplicit_copy_assign"};
             cprint.printName(print, decl) << fmt::nbsp;
             print.boolean(decl.hasCopyAssignmentWithConstParam());
-            printed = true;
         }
         if (!move_assign && decl.needsImplicitMoveAssignment()) {
+            nextImplicit();
             guard::ctor _{print, "Oimplicit_move_assign"};
             cprint.printName(print, decl);
-            printed = true;
         }
         if (!dtor && decl.needsImplicitDestructor()) {
+            nextImplicit();
             guard::ctor _{print, "Oimplicit_dtor"};
             cprint.printName(print, decl);
-            printed = true;
         }
         return printed;
     }

--- a/rocq-skylabs-cpp2v/src/PrintDecl.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintDecl.cpp
@@ -1210,7 +1210,7 @@ public:
         if (ClangPrinter::debug && cprint.trace(Trace::Decl))
             cprint.trace("VisitCXXRecordDecl", loc::of(decl));
         bool printed = false;
-        if (decl->isCompleteDefinition()) {
+        if (decl->isCompleteDefinition() && !print.templates()) {
             printed = printImplicitMembers(*decl, print, cprint, ctxt);
         }
         if (decl->isStruct() or decl->isClass()) {

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -1635,7 +1635,7 @@ public:
                    iinit != expr->capture_init_end();
                  ++icap, ++iinit) {
                 {
-                    guard::ctor _{print, "expr.set_declared_type"};
+                    guard::ctor _{print, "expr.Einitializing_type"};
                     cprint.printQualType(print, capture_type(*icap),
                                          loc::of(expr))
                         << fmt::nbsp;

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -424,10 +424,6 @@ public:
             cprint.printExpr(print, expr->getLHS());
             print.output() << fmt::nbsp;
             cprint.printExpr(print, expr->getRHS());
-            // TODO: Can be overloaded
-            always_assert(
-                (dependent || expr->getRHS()->getType() == expr->getType()) &&
-                "types must match");
             print.end_ctor(); // no type information
             return;
         case BinaryOperatorKind::BO_LAnd:
@@ -435,10 +431,6 @@ public:
             cprint.printExpr(print, expr->getLHS());
             print.output() << fmt::nbsp;
             cprint.printExpr(print, expr->getRHS());
-            // TODO: Can be overloaded
-            always_assert(
-                (dependent || expr->getType().getTypePtr()->isBooleanType()) &&
-                "&& is a bool");
             print.end_ctor(); // no type information
             return;
         case BinaryOperatorKind::BO_LOr:
@@ -446,10 +438,6 @@ public:
             cprint.printExpr(print, expr->getLHS());
             print.output() << fmt::nbsp;
             cprint.printExpr(print, expr->getRHS());
-            // TODO: Can be overloaded
-            always_assert(
-                (dependent || expr->getType().getTypePtr()->isBooleanType()) &&
-                "|| is a bool");
             print.end_ctor(); // no type information
             return;
         case BinaryOperatorKind::BO_Assign:

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -1084,9 +1084,15 @@ public:
 
     void
     VisitCXXDependentScopeMemberExpr(const CXXDependentScopeMemberExpr *expr) {
-        guard::ctor _{print, "Eunresolved_member"};
-        print.boolean(expr->isArrow()) << fmt::nbsp;
-        cprint.printExpr(print, expr->getBase(), names) << fmt::nbsp;
+        guard::ctor _{print, "core.Eunresolved_member"};
+        if (expr->isArrow()) {
+            guard::ctor arrow{print, "Eunresolved_unop", false};
+            print.output() << "Rarrow" << fmt::nbsp;
+            cprint.printExpr(print, expr->getBase(), names) << fmt::nbsp;
+        } else {
+            cprint.printExpr(print, expr->getBase(), names);
+        }
+        print.output() << fmt::nbsp;
         printDependentMember(cprint, print, expr);
     }
 

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -974,12 +974,18 @@ public:
 
     void VisitPredefinedExpr(const PredefinedExpr *expr) {
         // [PredefinedExpr] constructs a [string] which is always ascii
-        print.ctor("Estring");
-        print.ctor("BS.string_to_bytes");
-        print.str(expr->getFunctionName()->getString());
-        print.end_ctor();
-        print_string_type(expr, print, cprint);
-        print.end_ctor();
+        if (auto name = expr->getFunctionName()) {
+            guard::ctor _{print, "Estring"};
+            {
+                guard::ctor __{print, "BS.string_to_bytes"};
+                print.str(name->getString());
+            }
+            always_assert(!expr->getType()->isDependentType() && "dependent type of predefined expr");
+            print_string_type(expr, print, cprint);
+        } else {
+            guard::ctor _{print, "Eunresolved_string_literal"};
+            print.output() << "Tchar";
+        }
     }
 
     void VisitCXXBoolLiteralExpr(const CXXBoolLiteralExpr *lit) {

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -1592,11 +1592,57 @@ public:
 
     void VisitLambdaExpr(const LambdaExpr *expr) {
         print.ctor("Elambda");
-        cprint.printName(print, *expr->getLambdaClass()) << fmt::nbsp;
 
-        print.list(expr->capture_inits(), [&](auto capture) {
-            cprint.printExpr(print, capture, this->names);
-        });
+        auto LambdaClass = expr->getLambdaClass();
+
+        cprint.printName(print, *LambdaClass) << fmt::nbsp;
+
+        if (print.templates()) {
+            // get the mapping for captures so that we can compute their
+            // types
+            llvm::DenseMap<const ValueDecl *, FieldDecl *> CaptureFields;
+            FieldDecl *ThisCapture = nullptr;
+            LambdaClass->getCaptureFields(CaptureFields, ThisCapture);
+
+            auto capture_type = [&](const LambdaCapture &capture) -> QualType {
+                if (capture.capturesVariable()) {
+                    auto var = capture.getCapturedVar();
+                    auto field = CaptureFields[var];
+                    always_assert(field && "uncaptured field");
+                    return field->getType();
+                } else if (capture.capturesThis()) {
+                    always_assert(ThisCapture && "this capture is null");
+                    return ThisCapture->getType();
+                } else if (capture.capturesVLAType()) {
+                    guard::ctor _{print, "Eunsupported"};
+                    print.str("variable length array capture");
+                } else {
+                    always_assert(false && "unreachable lambda capture type");
+                }
+            };
+
+            auto icap = expr->capture_begin();
+            auto iinit = expr->capture_init_begin();
+            print.begin_list();
+            for (; icap != expr->capture_end() &&
+                   iinit != expr->capture_init_end();
+                 ++icap, ++iinit) {
+                {
+                    guard::ctor _{print, "expr.set_declared_type"};
+                    cprint.printQualType(print, capture_type(*icap),
+                                         loc::of(expr))
+                        << fmt::nbsp;
+                    cprint.printExpr(print, *iinit, this->names);
+                }
+                print.cons();
+            }
+            print.end_list();
+        } else {
+            print.list(expr->capture_inits(), [&](auto init) {
+                cprint.printExpr(print, init, this->names);
+            });
+        }
+
         print.end_ctor();
     }
 

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -1287,6 +1287,13 @@ public:
             // and are retained in the clang AST only for printing purposes.
             always_assert(expr->inits().size() == 1);
             cprint.printExpr(print, expr->getInit(0), names);
+        } else if (expr->getType()->isVoidType()) {
+            print.ctor("Eunresolved_initlist");
+            print.none();
+            print.output() << fmt::nbsp;
+            print.list(expr->inits(),
+                       [&](auto i) { cprint.printExpr(print, i, names); });
+            print.end_ctor();
         } else if (auto fld = expr->getInitializedFieldInUnion()) {
             print.ctor("Einitlist_union");
             assert(expr->inits().size() <= 1 &&

--- a/rocq-skylabs-cpp2v/src/PrintName.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintName.cpp
@@ -1178,9 +1178,7 @@ fmt::Formatter &printDeclarationName(CoqPrinter &print,
     }
 
     default:
-        llvm::errs() << "printDeclarationName(" << name.getNameKind() << ")";
-        name.dump();
-        print.output() << "(Nunsupported \"printDeclarationName("
+        print.output() << "(Nunsupported_atomic \"printDeclarationName("
                        << name.getNameKind() << ")\")";
     }
     return print.output();

--- a/rocq-skylabs-cpp2v/src/PrintName.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintName.cpp
@@ -397,16 +397,26 @@ static fmt::Formatter &printTemplateParameter(CoqPrinter &print,
     if (decl.isParameterPack())
         return unsupported("template parameter pack");
 
-    /*
-    TODO: We could presumably infer a name for some unnamed template
-    parameters.
+    auto get_name = [&]() -> std::string {
+        if (auto id = decl.getIdentifier())
+            return id->getName().str();
 
-    See `TemplateParmPosition`, `printTypeTemplateParam`.
-    */
-    auto id = decl.getIdentifier();
-    if (!id)
-        return unsupported("unnamed template parameter");
-    auto name = id->getName();
+        auto position_name = [](auto &param, StringRef prefix) {
+            return (prefix + Twine(param.getDepth()) + "_" +
+                    Twine(param.getIndex()))
+                .str();
+        };
+
+        if (auto param = dyn_cast<TemplateTypeParmDecl>(&decl))
+            return position_name(*param, "__type_");
+        if (auto param = dyn_cast<NonTypeTemplateParmDecl>(&decl))
+            return position_name(*param, "__value_");
+        if (auto param = dyn_cast<TemplateTemplateParmDecl>(&decl))
+            return position_name(*param, "__template_");
+
+        return "__template_param";
+    };
+    auto name = get_name();
 
     switch (decl.getKind()) {
     case Decl::Kind::TemplateTypeParm:
@@ -432,6 +442,20 @@ static fmt::Formatter &printTemplateParameter(CoqPrinter &print,
         }
 
     case Decl::Kind::TemplateTemplateParm:
+        if (as_arg) {
+            guard::ctor _(print, "Atemplate_param", false);
+            return print.str(name);
+        } else {
+            auto &param = cast<TemplateTemplateParmDecl>(decl);
+            guard::ctor _(print, "Ptemplate", false);
+            print.str(name) << fmt::nbsp;
+            return print.list(param.getTemplateParameters()->asArray(),
+                              [&](const clang::NamedDecl *p) {
+                                  printTemplateParameter(print, p, cprint,
+                                                         loc::of(p),
+                                                         /*as_arg=*/false);
+                              });
+        }
     default:
         return unsupported("template parameter kind");
     }
@@ -510,6 +534,10 @@ static fmt::Formatter &printTemplateArgument(CoqPrinter &print,
     case TemplateArgument::ArgKind::Template: {
         auto templ = arg.getAsTemplate();
         if (auto dt = templ.getAsTemplateDecl()) {
+            if (auto ttp = dyn_cast<TemplateTemplateParmDecl>(dt)) {
+                return printTemplateParameter(print, ttp, cprint, loc,
+                                              /*as_arg=*/true);
+            }
             guard::ctor _(print, "Atemplate", false);
             return cprint.printName(print, *dt);
         } /* else if (auto qtn = templ.getAsQualifiedTemplateName()) {
@@ -949,9 +977,8 @@ static fmt::Formatter &printName(CoqPrinter &print, const Decl &decl,
     auto parameters = [&](auto dct) {
         print.list(dct->getTemplateParameters()->asArray(),
                    [&](const clang::NamedDecl *p) {
-                       guard::ctor _(print, "Atype", false);
-                       guard::ctor __(print, "Tparam", false);
-                       print.str(p->getNameAsString());
+                       printTemplateParameter(print, p, cprint, loc::of(p),
+                                              /*as_arg=*/true);
                    });
     };
 

--- a/rocq-skylabs-cpp2v/src/PrintStmt.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintStmt.cpp
@@ -203,22 +203,38 @@ public:
         }
     }
 
+    static bool constexprEvalInt(const Expr &expr, ASTContext &ctxt,
+                                 llvm::APSInt &value) {
+        if (expr.containsErrors() || expr.isValueDependent() ||
+            expr.isTypeDependent())
+            return false;
+        Expr::EvalResult result;
+        if (!expr.EvaluateAsInt(result, ctxt))
+            return false;
+        value = result.Val.getInt();
+        return true;
+    }
+
     void VisitCaseStmt(const CaseStmt *stmt, CoqPrinter &print,
                        ClangPrinter &cprint, ASTContext &ctxt) {
-        // note, this only occurs when printing the body of a switch statement
-        print.ctor("Scase");
-
-        auto lo = stmt->getLHS()->EvaluateKnownConstInt(ctxt);
-        if (auto rhs = stmt->getRHS()) {
-            auto hi = rhs->EvaluateKnownConstInt(ctxt);
-            guard::ctor _(print, "Range");
+        llvm::APSInt lo, hi;
+        auto rhs = stmt->getRHS();
+        if (!constexprEvalInt(*stmt->getLHS(), ctxt, lo) ||
+            (rhs && !constexprEvalInt(*rhs, ctxt, hi))) {
+            // not evaluatable
+            guard::ctor _{print, "Sunsupported"};
+            print.str("unsupported (dependent) case label");
+        } else if (rhs) {
+            // evaluatable range
+            guard::ctor _{print, "Scase"};
+            guard::ctor __(print, "Range");
             print.output() << lo << fmt::nbsp << hi;
         } else {
-            guard::ctor _(print, "Exact");
+            // evaluatable simple case
+            guard::ctor _{print, "Scase"};
+            guard::ctor __(print, "Exact");
             print.output() << lo;
         }
-
-        print.end_ctor();
 
         print.cons();
 

--- a/rocq-skylabs-cpp2v/src/PrintType.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintType.cpp
@@ -470,7 +470,6 @@ public:
         // std::cerr << "VisitInjectedClassNameType: "
         // 		  // << type->getTemplateName()
         // 		  << " - " << type->getTemplateName(p).<< "\n";
-        always_assert(print.templates());
 
         if (auto decl = type->getDecl()) {
             /*

--- a/rocq-skylabs-cpp2v/tests/templates/dependent_arrow_member.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/dependent_arrow_member.t/run.t
@@ -1,0 +1,6 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v_templates_versions test.cpp 20
+  cpp2v -v -check-types -o test_20_cpp.v --templates test_20_cpp_templates.v test.cpp -- -std=c++20 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_20_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_20_cpp.v
+  $ coqc -w -notation-overridden test.v

--- a/rocq-skylabs-cpp2v/tests/templates/dependent_arrow_member.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/dependent_arrow_member.t/test.cpp
@@ -1,0 +1,2 @@
+template<class T>
+auto dependent_arrow_member(T* p) -> decltype(p->field);

--- a/rocq-skylabs-cpp2v/tests/templates/dependent_arrow_member.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/templates/dependent_arrow_member.t/test.v
@@ -1,0 +1,4 @@
+Require Import skylabs.lang.cpp.syntax.mtyped.
+Require Import test_20_cpp test_20_cpp_templates.
+
+Succeed Example _0 : check_mtu templates module = trace.Success tt := eq_refl.

--- a/rocq-skylabs-cpp2v/tests/templates/dependent_case.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/dependent_case.t/run.t
@@ -1,0 +1,6 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v_templates test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v --templates test_17_cpp_templates.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v
+  $ coqc -w -notation-overridden test.v

--- a/rocq-skylabs-cpp2v/tests/templates/dependent_case.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/dependent_case.t/test.cpp
@@ -1,0 +1,25 @@
+template<int X, int Y>
+int dependent_case_labels(int value)
+{
+  switch (value) {
+  case X:
+    return 1;
+  case 4 ... Y:
+    return 2;
+  case 9 ... 11:
+    return 3;
+  default:
+    return 0;
+  }
+}
+
+template<int X>
+int dependent_case_expression(int value)
+{
+  switch (value) {
+  case X + 1:
+    return X;
+  default:
+    return -1;
+  }
+}

--- a/rocq-skylabs-cpp2v/tests/templates/dependent_case.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/templates/dependent_case.t/test.v
@@ -1,0 +1,4 @@
+Require Import skylabs.lang.cpp.syntax.mtyped.
+Require Import test_17_cpp test_17_cpp_templates.
+
+Succeed Example _0 : check_mtu templates module = trace.Success tt := ltac:(vm_compute; reflexivity).

--- a/rocq-skylabs-cpp2v/tests/templates/lambda_captures.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/lambda_captures.t/run.t
@@ -1,0 +1,5 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v_templates test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v --templates test_17_cpp_templates.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v

--- a/rocq-skylabs-cpp2v/tests/templates/lambda_captures.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/lambda_captures.t/test.cpp
@@ -1,0 +1,45 @@
+template<typename T>
+int lambda_variable_captures(T input)
+{
+  int local = 3;
+  int other = 4;
+
+  auto by_copy = [local](int x) {
+    return local + x;
+  };
+  auto by_ref = [&other](int x) {
+    other += x;
+    return other;
+  };
+  auto init_capture = [sum = local + other](int x) {
+    return sum + x;
+  };
+  auto default_copy = [=](int x) {
+    return local + other + x;
+  };
+  auto default_ref = [&](int x) {
+    other += input;
+    return other + x;
+  };
+
+  return local + other;
+}
+
+template<typename T>
+struct LambdaCaptureOwner {
+  int value;
+
+  int member_captures(int delta) {
+    auto explicit_this = [this, delta]() {
+      return this->value + delta;
+    };
+    auto implicit_this = [=]() {
+      return value + delta;
+    };
+    auto copy_this = [*this, delta]() {
+      return value + delta;
+    };
+
+    return value + delta;
+  }
+};

--- a/rocq-skylabs-cpp2v/tests/templates/predefined_expr_dependent.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/predefined_expr_dependent.t/run.t
@@ -1,0 +1,6 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v_templates_versions test.cpp 23
+  cpp2v -v -check-types -o test_23_cpp.v --templates test_23_cpp_templates.v test.cpp -- -std=c++23 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_23_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_23_cpp.v
+  $ coqc -w -notation-overridden test.v

--- a/rocq-skylabs-cpp2v/tests/templates/predefined_expr_dependent.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/predefined_expr_dependent.t/test.cpp
@@ -1,0 +1,5 @@
+template<typename T>
+void f()
+{
+  (void)__PRETTY_FUNCTION__;
+}

--- a/rocq-skylabs-cpp2v/tests/templates/predefined_expr_dependent.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/templates/predefined_expr_dependent.t/test.v
@@ -1,0 +1,4 @@
+Require Import skylabs.lang.cpp.syntax.mtyped.
+Require Import test_23_cpp test_23_cpp_templates.
+
+Succeed Example _0 : check_mtu templates module = trace.Success tt := eq_refl.

--- a/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/run.t
@@ -1,0 +1,2 @@
+  $ . ../../setup-cpp2v.sh
+  $ cpp2v -o /dev/null --templates /dev/null test.cpp -- -std=c++23

--- a/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/run.t
@@ -1,2 +1,6 @@
   $ . ../../setup-cpp2v.sh
-  $ cpp2v -o /dev/null --templates /dev/null test.cpp -- -std=c++23
+  $ check_cpp2v_templates test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v --templates test_17_cpp_templates.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v
+  $ coqc -w -notation-overridden test.v

--- a/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/test.cpp
@@ -1,0 +1,5 @@
+template <template <class> class L>
+struct B;
+
+template <template <class> class L>
+void f(B<L>);

--- a/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/templates/template_template_param_type.t/test.v
@@ -1,0 +1,4 @@
+Require Import skylabs.lang.cpp.syntax.mtyped.
+Require Import test_17_cpp test_17_cpp_templates.
+
+Succeed Example _0 : check_mtu templates module = trace.Success tt := eq_refl.

--- a/rocq-skylabs-cpp2v/tests/templates/test_template_operators.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/test_template_operators.t/run.t
@@ -1,0 +1,6 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v_templates test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v --templates test_17_cpp_templates.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v
+  $ coqc -w -notation-overridden test.v

--- a/rocq-skylabs-cpp2v/tests/templates/test_template_operators.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/test_template_operators.t/test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 BlueRock Security, Inc.
+ *
+ * SPDX-License-Identifier:MIT-0
+ */
+
+template<typename T>
+int type_size() { return sizeof(T); }
+
+template<typename T>
+struct Box {
+  T value;
+  Box() : value{} {}
+};
+
+template<typename T>
+void test(T& t) {
+  t && t;
+  t || t;
+  t , t;
+}
+
+struct C {};
+
+void test() {
+  Box<int> box_int;
+  Box<C> box_C;
+  Box<Box<int> > box_box_int;
+
+  type_size<Box<int> >();
+  type_size<Box<char> >();
+  type_size<Box<C> >();
+  type_size<Box<Box<C> > >();
+
+}

--- a/rocq-skylabs-cpp2v/tests/templates/test_template_operators.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/templates/test_template_operators.t/test.v
@@ -1,0 +1,4 @@
+Require Import skylabs.lang.cpp.syntax.mtyped.
+Require Import test_17_cpp test_17_cpp_templates.
+
+Succeed Example _0 : check_mtu templates module = trace.Success tt := eq_refl.

--- a/rocq-skylabs-cpp2v/tests/templates/unresolved_initlist.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/templates/unresolved_initlist.t/run.t
@@ -1,0 +1,5 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v_templates test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v --templates test_17_cpp_templates.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp_templates.v
+  coqc -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v

--- a/rocq-skylabs-cpp2v/tests/templates/unresolved_initlist.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/templates/unresolved_initlist.t/test.cpp
@@ -1,0 +1,14 @@
+template<typename T>
+void unresolved_initializer_lists(T target)
+{
+  target.consume({1, 2, 3});
+  target.consume({T::value, 4});
+  target.consume({{1}, {2, 3}});
+}
+
+template<typename T>
+void unresolved_constructor_initializer()
+{
+  T value({1, 2, 3});
+  (void)value;
+}


### PR DESCRIPTION
This fixes a number of issues that arise in template ASTs.

- Bug fix for printing of Bor and Band in notation
- **Templates** Support for unresolved `,`, `&&`, and `||` operators -- these almost never occur in practice
- **Templates** Support for `template`-`template` parameters
- **Templates** Support for unresolved string literals, e.g. `func` inside of a template definition
- **Templates** Support for unresolved arrows
- **Templates** Dependent `case` statements (not fully supported, but no longer result in a crash)
- **Templates** Improvements for typing information
- **Templates** Support unresolved initlist expressions
- Promote `compile_commands.json` for better editing support
- Type checker improvements