### PR TITLE
Bind scope for cstring.t

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/logic/cstring.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/cstring.v
@@ -1135,6 +1135,7 @@ Module cstring.
     End Theory.
   End with_Σ.
 End cstring.
+#[global] Bind Scope bs_scope with cstring.t.
 
 Require Import skylabs.lang.cpp.logic.core_string.
 


### PR DESCRIPTION
As noted by @pgiarrusso-sl in brick-libcpp