### PR TITLE
Unsupported on verbose

### DIFF
--- a/rocq-skylabs-cpp2v/include/Logging.hpp
+++ b/rocq-skylabs-cpp2v/include/Logging.hpp
@@ -13,8 +13,8 @@ namespace logging {
 enum Level : int {
     FATAL = -1,
     NONE = 0,
-    UNSUPPORTED = 5,
     VERBOSE = 10,
+    UNSUPPORTED = 15,
     VERBOSER = 20,
     ALL = 1000,
 };

--- a/rocq-skylabs-cpp2v/src/PrintType.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintType.cpp
@@ -76,6 +76,7 @@ public:
 
     IGNORE(BlockPointerType)
     IGNORE(PackExpansionType)
+    IGNORE(VectorType)
 
     void VisitAttributedType(const AttributedType *type, CoqPrinter &print,
                              ClangPrinter &cprint) {


### PR DESCRIPTION
Move unsupported warnings to verbose mode (or higher)