### PR TITLE
rocq-skylabs-brick: depend on rocq-skylabs-cpp2v

### DIFF
--- a/rocq-skylabs-brick/dune-project
+++ b/rocq-skylabs-brick/dune-project
@@ -37,7 +37,11 @@
   rocq-equations
   rocq-skylabs-prelude
   rocq-skylabs-iris
-  (rocq-skylabs-cpp2v :with-test)
+  rocq-skylabs-cpp2v
+  ; this package mostly does not depend on cpp2v, except
+  ; that rocq-skylabs-brick/theories/lang/cpp/dune uses
+  ; cpp2v's hash in build parser/plugin/cpp2v.v.
+  ; TODO: make that a separate package.
   rocq-flocq
   coq-elpi))
 

--- a/rocq-skylabs-brick/rocq-skylabs-brick.opam
+++ b/rocq-skylabs-brick/rocq-skylabs-brick.opam
@@ -31,7 +31,7 @@ depends: [
   "rocq-equations"
   "rocq-skylabs-prelude"
   "rocq-skylabs-iris"
-  "rocq-skylabs-cpp2v" {with-test}
+  "rocq-skylabs-cpp2v"
   "rocq-flocq"
   "coq-elpi"
   "odoc" {with-doc}


### PR DESCRIPTION
V2 of #185. Fixes a build failure in the nightly paranoid opam job.