### PR TITLE
Support for C-style `typedef struct C C;`

### DIFF
--- a/rocq-skylabs-cpp2v/src/ModuleBuilder.cpp
+++ b/rocq-skylabs-cpp2v/src/ModuleBuilder.cpp
@@ -164,10 +164,31 @@ public:
         return decl && decl == decl->getCanonicalDecl();
     }
 
+    static const TagDecl *selfTypedefTag(const TypedefNameDecl &decl) {
+        if (!decl.getIdentifier())
+            return nullptr;
+
+        const Type *type = decl.getUnderlyingType().getTypePtrOrNull();
+        const auto *tag = type ? type->getAsTagDecl() : nullptr;
+        if (!tag || !isa<RecordDecl>(tag) || !tag->getIdentifier())
+            return nullptr;
+
+        if (decl.getName() == tag->getName())
+            return tag;
+        return nullptr;
+    }
+
     void VisitTypedefNameDecl(const TypedefNameDecl *decl, Flags flags) {
         if (decl->getAnonDeclWithTypedefName(true)) {
             // these [typedef]s become the name of the anonymous struct, so we
             // ignore them.
+            return;
+        }
+        if (auto tag = selfTypedefTag(*decl)) {
+            // C commonly uses [typedef struct C C] to make the tag name
+            // available as a type name. In cpp2v both declarations have the
+            // same key, so emit the record and suppress the redundant alias.
+            Visit(tag, flags);
             return;
         }
         if (not decl->isCanonicalDecl())
@@ -188,6 +209,13 @@ public:
         } else if (defn == nullptr && decl->getPreviousDecl() == nullptr) {
             go(decl, flags, false);
         }
+    }
+
+    void VisitRecordDecl(const RecordDecl *decl, Flags flags) {
+        if (isa<CXXRecordDecl>(decl))
+            return;
+        VisitTagDecl(decl, flags);
+        VisitDeclContext(decl, flags);
     }
 
     void VisitDeclContext(const DeclContext *dc, Flags flags) {

--- a/rocq-skylabs-cpp2v/src/PrintDecl.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintDecl.cpp
@@ -17,6 +17,7 @@
 #include "clang/Basic/Builtins.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Sema/Sema.h"
+#include <clang/AST/DeclCXX.h>
 #include <clang/AST/Type.h>
 #include <clang/Basic/Version.inc>
 #include <optional>
@@ -343,10 +344,12 @@ static fmt::Formatter &printLayoutInfo(CoqPrinter &print,
     return print.output() << li;
 }
 
-static const CXXRecordDecl *getTypeAsRecord(const ValueDecl &decl) {
-    if (auto type = decl.getType().getTypePtrOrNull())
-        return type->getAsCXXRecordDecl();
-    else
+static const RecordDecl *getTypeAsRecord(const ValueDecl &decl) {
+    if (auto type = decl.getType().getTypePtrOrNull()) {
+        if (auto tag = type->getAsTagDecl())
+            return dyn_cast<RecordDecl>(tag);
+        return nullptr;
+    } else
         return nullptr;
 }
 
@@ -401,7 +404,7 @@ static fmt::Formatter &printFieldInitializer(CoqPrinter &print,
         return print.none();
 }
 
-static fmt::Formatter &printFields(const CXXRecordDecl &decl,
+static fmt::Formatter &printFields(const RecordDecl &decl,
                                    const ASTRecordLayout *layout,
                                    CoqPrinter &print, ClangPrinter &cprint) {
     auto i = 0;
@@ -542,6 +545,14 @@ static fmt::Formatter &printSizeAlign(const CXXRecordDecl &decl,
     return print.output() << size << fmt::nbsp << align;
 }
 
+static fmt::Formatter &printSizeAlign(const RecordDecl &decl,
+                                      const ASTRecordLayout *layout,
+                                      CoqPrinter &print, ClangPrinter &cprint) {
+    auto size = layout ? layout->getSize().getQuantity() : 0;
+    auto align = layout ? layout->getAlignment().getQuantity() : 0;
+    return print.output() << size << fmt::nbsp << align;
+}
+
 static fmt::Formatter &printStruct(CoqPrinter &print, const CXXRecordDecl &decl,
                                    ClangPrinter &cprint,
                                    const ASTContext &ctxt) {
@@ -602,12 +613,66 @@ static fmt::Formatter &printUnion(CoqPrinter &print, const CXXRecordDecl &decl,
     return printSizeAlign(decl, layout, print, cprint);
 }
 
-static const char *supportedRecord(const CXXRecordDecl &decl,
+static fmt::Formatter &printCStruct(CoqPrinter &print, const RecordDecl &decl,
+                                    ClangPrinter &cprint,
+                                    const ASTContext &ctxt) {
+    if (ClangPrinter::debug && cprint.trace(Trace::Decl))
+        cprint.trace("printCStruct", loc::of(decl));
+#if 18 <= CLANG_VERSION_MAJOR
+    always_assert(decl.getTagKind() == TagTypeKind::Struct);
+#else
+    always_assert(decl.getTagKind() == TagTypeKind::TTK_Struct);
+#endif
+
+    if (!decl.isCompleteDefinition())
+        return print.none();
+
+    const auto layout =
+        decl.isDependentContext() ? nullptr : &ctxt.getASTRecordLayout(&decl);
+
+    guard::some some(print);
+    guard::ctor _(print, "Build_Struct");
+
+    print.output() << "nil" << fmt::line;
+    printFields(decl, layout, print, cprint) << fmt::nbsp;
+    print.output() << "nil" << fmt::nbsp;
+    print.output() << "nil" << fmt::nbsp;
+    print.none() << fmt::nbsp;
+    print.boolean(true) << fmt::nbsp;
+    print.none() << fmt::line;
+    print.output() << "POD" << fmt::nbsp;
+    return printSizeAlign(decl, layout, print, cprint);
+}
+
+static fmt::Formatter &printCUnion(CoqPrinter &print, const RecordDecl &decl,
+                                   ClangPrinter &cprint,
                                    const ASTContext &ctxt) {
-    for (auto base : decl.bases()) {
-        if (base.isVirtual())
-            return "virtual base classes are not supported";
-    }
+    if (ClangPrinter::debug && cprint.trace(Trace::Decl))
+        cprint.trace("printCUnion", loc::of(decl));
+#if 18 <= CLANG_VERSION_MAJOR
+    always_assert(decl.getTagKind() == TagTypeKind::Union);
+#else
+    always_assert(decl.getTagKind() == TagTypeKind::TTK_Union);
+#endif
+
+    if (!decl.isCompleteDefinition())
+        return print.none();
+
+    const auto layout =
+        decl.isDependentContext() ? nullptr : &ctxt.getASTRecordLayout(&decl);
+
+    guard::some some(print);
+    guard::ctor _(print, "Build_Union");
+
+    printFields(decl, layout, print, cprint) << fmt::nbsp;
+    print.none() << fmt::nbsp;
+    print.boolean(true) << fmt::nbsp;
+    print.none() << fmt::line;
+    return printSizeAlign(decl, layout, print, cprint);
+}
+
+static const char *supportedRecord(const RecordDecl &decl,
+                                   const ASTContext &ctxt) {
     for (auto f : decl.fields()) {
         if (f->isBitField())
             return "bitfields are not supported";
@@ -616,10 +681,22 @@ static const char *supportedRecord(const CXXRecordDecl &decl,
     }
     return nullptr;
 }
+static const char *supportedRecord(const CXXRecordDecl &decl,
+                                   const ASTContext &ctxt) {
+    for (auto base : decl.bases()) {
+        if (base.isVirtual())
+            return "virtual base classes are not supported";
+    }
+    return supportedRecord(static_cast<const RecordDecl&>(decl), ctxt);
+}
+
 } // namespace
 
 static const DeclPrinter Dstruct("Dstruct", printStruct, supportedRecord);
 static const DeclPrinter Dunion("Dunion", printUnion, supportedRecord);
+static const DeclPrinter Drecord_struct("Dstruct", printCStruct,
+                                        supportedRecord);
+static const DeclPrinter Drecord_union("Dunion", printCUnion, supportedRecord);
 
 // Functions
 namespace {
@@ -1240,6 +1317,27 @@ public:
             os << "CXXRecord with tag kind " << decl->getKindName();
             unsupported(cprint, loc::of(decl), msg);
             return printed;
+        }
+    }
+
+    bool VisitRecordDecl(const RecordDecl *decl, CoqPrinter &print,
+                         ClangPrinter &cprint, const ASTContext &ctxt) {
+
+        if (ClangPrinter::debug && cprint.trace(Trace::Decl))
+            cprint.trace("VisitRecordDecl", loc::of(decl));
+
+        // the visitor should always visit the subclass first
+        always_assert(!isa<CXXRecordDecl>(decl));
+        if (decl->isStruct()) {
+            return printType(Drecord_struct, *decl, print, cprint, ctxt);
+        } else if (decl->isUnion()) {
+            return printType(Drecord_union, *decl, print, cprint, ctxt);
+        } else {
+            std::string msg;
+            llvm::raw_string_ostream os{msg};
+            os << "Record with tag kind " << decl->getKindName();
+            unsupported(cprint, loc::of(decl), msg);
+            return false;
         }
     }
 

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_function_typedef_decl.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_function_typedef_decl.t/run.t
@@ -1,0 +1,4 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  rocq c -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_function_typedef_decl.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_function_typedef_decl.t/test.cpp
@@ -1,0 +1,2 @@
+typedef int (AppInitProc)(int *);
+extern AppInitProc AppInit;

--- a/rocq-skylabs-cpp2v/tests/typedef_struct.t/Makefile
+++ b/rocq-skylabs-cpp2v/tests/typedef_struct.t/Makefile
@@ -1,0 +1,10 @@
+CPPFLAGS = -std=c++17
+
+GEN_FILES = cases_cpp.v
+
+Q = @
+
+all: $(GEN_FILES)
+
+cases_cpp.v: cases.cpp
+	$(Q)cpp2v -v -o $@ $< --check-types -- $(CPPFLAGS)

--- a/rocq-skylabs-cpp2v/tests/typedef_struct.t/cases.cpp
+++ b/rocq-skylabs-cpp2v/tests/typedef_struct.t/cases.cpp
@@ -1,0 +1,21 @@
+typedef struct Before Before;
+struct Before {
+  int x;
+};
+
+struct After {
+  int x;
+};
+typedef struct After After;
+
+typedef struct Inline {
+  int x;
+} Inline;
+
+typedef struct ForwardOnly ForwardOnly;
+
+struct D;
+typedef struct D Dtypedef;
+
+// no [struct X]
+typedef struct X Xtypedef;

--- a/rocq-skylabs-cpp2v/tests/typedef_struct.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/typedef_struct.t/run.t
@@ -1,0 +1,7 @@
+  $ . ../setup-project.sh
+
+Compiling the C++ code, use "make Q=" for debugging.
+  $ make
+
+Compiling the generated Coq files.
+  $ dune build

--- a/rocq-skylabs-cpp2v/tests/typedef_struct.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/typedef_struct.t/test.v
@@ -1,0 +1,54 @@
+Require Import skylabs.prelude.base.
+Require Import skylabs.lang.cpp.syntax.
+
+Require test.cases_cpp.
+
+Definition type_is_gstruct (n : name) : bool :=
+  match test.cases_cpp.module.(types) !! n with
+  | Some (Gstruct _) => true
+  | _ => false
+  end.
+
+Definition type_is_gtype (n : name) : bool :=
+  match test.cases_cpp.module.(types) !! n with
+  | Some Gtype => true
+  | _ => false
+  end.
+
+Definition type_is_typedef_to (n target : name) : bool :=
+  match test.cases_cpp.module.(types) !! n with
+  | Some (Gtypedef (Tnamed target')) => bool_decide (target' = target)
+  | _ => false
+  end.
+
+Example typedef_before_record :
+  type_is_gstruct "Before" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example typedef_after_record :
+  type_is_gstruct "After" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example typedef_inline_record :
+  type_is_gstruct "Inline" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example typedef_forward_only :
+  type_is_gtype "ForwardOnly" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example regular_typedef_keeps_tag :
+  type_is_gtype "D" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example regular_typedef_keeps_alias :
+  type_is_typedef_to "Dtypedef" "D" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example regular_typedef_keeps_alias_only :
+  type_is_typedef_to "Xtypedef" "X" = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example regular_typedef_keeps_tag_only :
+  type_is_gtype "X" = true :=
+  ltac:(vm_compute; reflexivity).


### PR DESCRIPTION
Without this PR, if you write:

```c++
typedef struct C C;
```

then cpp2v will generate `Dtypedef "C" (Nglobal "C")` but it should generate either `Dtype "C"` or `Dstruct "C" ..`.