### PR TITLE
Move to [rocq-elpi] in opam packages.

### DIFF
--- a/elpi-extra/dune-project
+++ b/elpi-extra/dune-project
@@ -17,6 +17,6 @@
 (package
  (name elpi-extra)
  (synopsis "Extension of the (Rocq) Elpi standard library")
- (depends rocq-stdlib coq-elpi ltac2-extra))
+ (depends rocq-stdlib rocq-elpi ltac2-extra))
 
 (subst disabled)

--- a/elpi-extra/elpi-extra.opam
+++ b/elpi-extra/elpi-extra.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/SkyLabsAI/BRiCk/issues"
 depends: [
   "dune" {>= "3.22"}
   "rocq-stdlib"
-  "coq-elpi"
+  "rocq-elpi"
   "ltac2-extra"
   "odoc" {with-doc}
 ]

--- a/rocq-lens/Lens/Elpi/dune
+++ b/rocq-lens/Lens/Elpi/dune
@@ -11,7 +11,7 @@
  )
  (package rocq-lens-elpi))
 
-; Hack to ensure the coq-elpi package is avalable. *)
+; Hack to ensure the rocq-elpi package is avalable. *)
 (rule
  (targets dummy.v)
  (action (with-stdout-to %{targets} (echo "(* dummy file *)"))))

--- a/rocq-lens/dune-project
+++ b/rocq-lens/dune-project
@@ -28,6 +28,6 @@
  (synopsis "Generation of lenses for record datatypes, Elpi backend")
  (depends
   rocq-lens
-  coq-elpi))
+  rocq-elpi))
 
 (subst disabled)

--- a/rocq-lens/rocq-lens-elpi.opam
+++ b/rocq-lens/rocq-lens-elpi.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/SkyLabsAI/BRiCk/issues"
 depends: [
   "dune" {>= "3.22"}
   "rocq-lens"
-  "coq-elpi"
+  "rocq-elpi"
   "odoc" {with-doc}
 ]
 build: [

--- a/rocq-skylabs-brick/dune-project
+++ b/rocq-skylabs-brick/dune-project
@@ -43,6 +43,6 @@
   ; cpp2v's hash in build parser/plugin/cpp2v.v.
   ; TODO: make that a separate package.
   rocq-flocq
-  coq-elpi))
+  rocq-elpi))
 
 (subst disabled)

--- a/rocq-skylabs-brick/rocq-skylabs-brick.opam
+++ b/rocq-skylabs-brick/rocq-skylabs-brick.opam
@@ -33,7 +33,7 @@ depends: [
   "rocq-skylabs-iris"
   "rocq-skylabs-cpp2v"
   "rocq-flocq"
-  "coq-elpi"
+  "rocq-elpi"
   "odoc" {with-doc}
 ]
 build: [

--- a/rocq-skylabs-iris/dune-project
+++ b/rocq-skylabs-iris/dune-project
@@ -37,6 +37,6 @@
   rocq-lens
   rocq-lens-elpi
   ltac2-extra
-  coq-elpi))
+  rocq-elpi))
 
 (subst disabled)

--- a/rocq-skylabs-iris/rocq-skylabs-iris.opam
+++ b/rocq-skylabs-iris/rocq-skylabs-iris.opam
@@ -31,7 +31,7 @@ depends: [
   "rocq-lens"
   "rocq-lens-elpi"
   "ltac2-extra"
-  "coq-elpi"
+  "rocq-elpi"
   "odoc" {with-doc}
 ]
 build: [

--- a/rocq-skylabs-prelude/dune-project
+++ b/rocq-skylabs-prelude/dune-project
@@ -35,7 +35,7 @@
   rocq-stdpp
   rocq-lens
   rocq-lens-elpi
-  coq-elpi
+  rocq-elpi
   ltac2-extra))
 
 (subst disabled)

--- a/rocq-skylabs-prelude/rocq-skylabs-prelude.opam
+++ b/rocq-skylabs-prelude/rocq-skylabs-prelude.opam
@@ -29,7 +29,7 @@ depends: [
   "rocq-stdpp"
   "rocq-lens"
   "rocq-lens-elpi"
-  "coq-elpi"
+  "rocq-elpi"
   "ltac2-extra"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This also tests a tweaked `rocq-elpi` with generated `_RocqProject` files.