### PR TITLE
Extend bin-hash, use to version cpp2v plugin

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/dune
+++ b/rocq-skylabs-brick/theories/lang/cpp/dune
@@ -2,7 +2,7 @@
 (rocq.theory
  (name skylabs.lang.cpp)
  (package rocq-skylabs-brick)
- (modules (:standard \ parser.plugin.cpp2v_template))
+ (modules :standard)
  (plugins rocq-skylabs-brick.plugin)
  (generate_project_file)
  (theories
@@ -31,10 +31,9 @@
 
 (subdir parser/plugin
  (rule
-  (target cpp2v.v)
+  (target cpp2v_version.v)
   (deps
-   cpp2v_template.v
    (package rocq-skylabs-cpp2v))
   (action
    (with-stdout-to %{target}
-    (bash "checksum=$(sha1sum %{bin:cpp2v} | cut -d' ' -f 1); sed \"s/PLACEHOLDER/${checksum}/g\" cpp2v_template.v")))))
+    (run %{bin:bin-hash} --rocq version %{bin:cpp2v})))))

--- a/rocq-skylabs-brick/theories/lang/cpp/dune
+++ b/rocq-skylabs-brick/theories/lang/cpp/dune
@@ -2,7 +2,6 @@
 (rocq.theory
  (name skylabs.lang.cpp)
  (package rocq-skylabs-brick)
- (modules :standard)
  (plugins rocq-skylabs-brick.plugin)
  (generate_project_file)
  (theories

--- a/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v.v
@@ -3,16 +3,15 @@
  * This software is distributed under the terms of the BedRock Open-Source License.
  * See the LICENSE-BedRock file in the repository root for details.
  *)
-Require Import Stdlib.Strings.String.
+Require skylabs.lang.cpp.parser.plugin.cpp2v_version.
 Require Stdlib.Array.PArray.
 Require Import Stdlib.Numbers.Cyclic.Int63.PrimInt63.
 Require Import skylabs.lang.cpp.parser.
 Require skylabs.lang.cpp.syntax.typed.
 
-#[local] Open Scope string_scope.
 #[local] Set Printing Universes.
 
-Definition version : string := "PLACEHOLDER".
+Definition version := cpp2v_version.version.
 
 Register translation_unit.t as skylabs.lang.cpp.parser.translation_unit.t.
 Register translation_unit._skip as skylabs.lang.cpp.parser.translation_unit.skip.

--- a/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser/plugin/cpp2v.v
@@ -11,8 +11,6 @@ Require skylabs.lang.cpp.syntax.typed.
 
 #[local] Set Printing Universes.
 
-Definition version := cpp2v_version.version.
-
 Register translation_unit.t as skylabs.lang.cpp.parser.translation_unit.t.
 Register translation_unit._skip as skylabs.lang.cpp.parser.translation_unit.skip.
 Register abi.t as skylabs.lang.cpp.parser.translation_unit.abi_type.

--- a/rocq-tools/bin/bin_hash.ml
+++ b/rocq-tools/bin/bin_hash.ml
@@ -14,8 +14,9 @@ let _ =
     match Sys.argv with
     | [|_; "--ocaml"; val_name; bin_name|] -> (`OCaml, val_name, bin_name)
     | [|_; "--rocq" ; val_name; bin_name|] -> (`Rocq , val_name, bin_name)
+    | [|_; "--sh"   ; val_name; bin_name|] -> (`Sh   , val_name, bin_name)
     | _                                    ->
-        panic "Usage: %s (--ocaml | --rocq) VALUE_NAME BIN_NAME" Sys.argv.(0)
+        panic "Usage: %s (--ocaml | --rocq | --sh) VALUE_NAME BIN_NAME" Sys.argv.(0)
   in
   let path = bin_path bin_name in
   let hash = Digest.MD5.(to_hex (file path)) in
@@ -25,3 +26,5 @@ let _ =
   | `Rocq  ->
       Printf.printf "Require Import PrimString.\n\n";
       Printf.printf "Definition %s := %S%%pstring.\n%!" val_name hash
+  | `Sh    ->
+      Printf.printf "%s=%S\n%!" val_name hash

--- a/rocq-tools/bin/dune
+++ b/rocq-tools/bin/dune
@@ -109,7 +109,7 @@
  (package rocq-tools)
  (libraries rocq_tools yojson))
 
-; Generate an OCaml or Rocq file holding the hash of a binary.
+; Generate an OCaml, Rocq, or shell file holding the hash of a binary.
 (executable
  (name bin_hash)
  (public_name bin-hash)

--- a/rocq-tools/tests/bin-hash.t/run.t
+++ b/rocq-tools/tests/bin-hash.t/run.t
@@ -1,0 +1,14 @@
+  $ printf 'bin-hash test data\n' > test-bin
+  $ chmod +x test-bin
+  $ export PATH="$PWD:$PATH"
+
+  $ bin-hash --ocaml test_hash test-bin
+  let test_hash = "4d3b619ef25836df47b0e038b25121dd"
+
+  $ bin-hash --rocq test_hash test-bin
+  Require Import PrimString.
+  
+  Definition test_hash := "4d3b619ef25836df47b0e038b25121dd"%pstring.
+
+  $ bin-hash --sh TEST_HASH test-bin
+  TEST_HASH="4d3b619ef25836df47b0e038b25121dd"


### PR DESCRIPTION
Motivated by https://github.com/SkyLabsAI/workspace/issues/159. I'll see separately if I can use it `bin-hash --sh` in that build as well.