### PR TITLE
Record static_assert in translation_units

### DIFF
--- a/rocq-skylabs-brick/tests/cpp_prog.expected
+++ b/rocq-skylabs-brick/tests/cpp_prog.expected
@@ -33,6 +33,7 @@ module =
            (internal.NameMap.Raw.Leaf (listset name)) I
      |});
   initializer := [];
+  asserts := [];
   abi :=
     {|
       abi.uintptr_t_rank := int_rank.Ilong;

--- a/rocq-skylabs-brick/tests/static_asserts.v
+++ b/rocq-skylabs-brick/tests/static_asserts.v
@@ -1,0 +1,12 @@
+Require Import skylabs.lang.cpp.parser.
+Require Import skylabs.lang.cpp.parser.plugin.cpp2v.
+
+cpp.prog module prog cpp:{{
+  static_assert(true, "truth survives parsing");
+  static_assert(true);
+}}.
+
+Goal module.(asserts) =
+  [Build_StaticAssert "" (Ebool true);
+   Build_StaticAssert "truth survives parsing" (Ebool true)]%pstring.
+Proof. reflexivity. Qed.

--- a/rocq-skylabs-brick/tests/static_asserts.v
+++ b/rocq-skylabs-brick/tests/static_asserts.v
@@ -10,3 +10,16 @@ Goal module.(asserts) =
   [Build_StaticAssert "" (Ebool true);
    Build_StaticAssert "truth survives parsing" (Ebool true)]%pstring.
 Proof. reflexivity. Qed.
+
+cpp.prog ordered prog cpp:{{
+  static_assert(true, "a");
+  static_assert(true, "b");
+}}.
+
+cpp.prog permuted prog cpp:{{
+  static_assert(true, "b");
+  static_assert(true, "a");
+}}.
+
+Goal ordered = permuted.
+Proof. reflexivity. Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/parser.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser.v
@@ -64,7 +64,7 @@ Module Import translation_unit.
       | l :: ls' =>
           match compare x l with
           | Lt => x :: ls
-          | Eq => x :: l :: ls'
+          | Eq => ls (* remove duplicates *)
           | Gt => l :: insert x ls'
           end
       end.

--- a/rocq-skylabs-brick/theories/lang/cpp/parser.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/parser.v
@@ -51,6 +51,31 @@ Module Import translation_unit.
       end.
   End sort.
 
+  Module sort_static_assert.
+    Definition compare (x y : StaticAssert) : comparison :=
+      match PrimString.compare x.(sa_message) y.(sa_message) with
+      | Eq => base.compare x.(sa_condition) y.(sa_condition)
+      | c => c
+      end.
+
+    Fixpoint insert (x : StaticAssert) (ls : list StaticAssert) : list StaticAssert :=
+      match ls with
+      | nil => x :: nil
+      | l :: ls' =>
+          match compare x l with
+          | Lt => x :: ls
+          | Eq => x :: l :: ls'
+          | Gt => l :: insert x ls'
+          end
+      end.
+
+    Fixpoint sort (ls : list StaticAssert) : list StaticAssert :=
+      match ls with
+      | nil => nil
+      | l :: ls => insert l $ sort ls
+      end.
+  End sort_static_assert.
+
   (**
   We work with an exploded [translation_unit] and raw trees for
   efficiency.
@@ -65,8 +90,8 @@ Module Import translation_unit.
   Definition dup_info := list (name * (GlobDecl + ObjValue)).
   (** This representation is isomorphic to [translation_unit * list name] as shown by [decls]. *)
   Definition t : Type :=
-    raw_symbol_table -> raw_type_table -> list name -> raw_alias_table -> dup_info ->
-    (raw_symbol_table -> raw_type_table -> list name -> raw_alias_table -> dup_info -> translation_unit * dup_info) ->
+    raw_symbol_table -> raw_type_table -> list name -> raw_alias_table -> list StaticAssert -> dup_info ->
+    (raw_symbol_table -> raw_type_table -> list name -> raw_alias_table -> list StaticAssert -> dup_info -> translation_unit * dup_info) ->
     translation_unit * dup_info.
 
   Definition merge_obj_value (a b : ObjValue) : option ObjValue :=
@@ -77,12 +102,12 @@ Module Import translation_unit.
 
   (** Constructs a [translation_unit.t] with _one_ symbol, mapping [n] to [v]. *)
   Definition _symbols (n : name) (v : ObjValue) : t :=
-    fun s t ga a dups k =>
+    fun s t ga a asserts dups k =>
       match s !! n with
-      | None => k (<[n := v]> s) t ga a dups
+      | None => k (<[n := v]> s) t ga a asserts dups
       | Some v' => match merge_obj_value v v' with
-                  | Some v => k (<[n:=v]> s) t ga a dups
-                  | None => k s t ga a ((n, inr v) :: (n, inr v') :: dups)
+                  | Some v => k (<[n:=v]> s) t ga a asserts dups
+                  | None => k s t ga a asserts ((n, inr v) :: (n, inr v') :: dups)
                   end
       end.
   Definition merge_glob_decl (a b : GlobDecl) : option GlobDecl :=
@@ -93,7 +118,7 @@ Module Import translation_unit.
 
   (** Constructs a [translation_unit.t] with _one_ type, mapping [n] to [v]. *)
   Definition _types (n : name) (v : GlobDecl) : t :=
-    fun s t ga a dups k =>
+    fun s t ga a asserts dups k =>
       if bool_decide (Gtypedef (Tnamed n) = v \/ Gtypedef (Tenum n) = v)
       then
         (* ignore self-aliases. These arise when you do
@@ -102,13 +127,13 @@ Module Import translation_unit.
            typedef enum memory_order { .. } memory_order;
            >>
          *)
-        k s t ga a dups
+        k s t ga a asserts dups
       else
         match t !! n with
-        | None => k s (<[n := v]> t) ga a dups
+        | None => k s (<[n := v]> t) ga a asserts dups
         | Some v' => match merge_glob_decl v v' with
-                    | Some v => k s (<[n:=v]> t) ga a dups
-                    | None => k s t ga a ((n, inl v) :: (n, inl v') :: dups)
+                    | Some v => k s (<[n:=v]> t) ga a asserts dups
+                    | None => k s t ga a asserts ((n, inl v) :: (n, inl v') :: dups)
                     end
         end.
 
@@ -116,18 +141,26 @@ Module Import translation_unit.
     _types n (Gtypedef ty).
 
   Definition _value_alias (n : name) (canon : name) : t :=
-    fun s t ga a dups k =>
+    fun s t ga a asserts dups k =>
       match a !! n with
-      | None => k s t ga (<[n := canon :: nil]> a) dups
-      | Some canon' => k s t ga (<[n := canon :: canon']> a) dups
+      | None => k s t ga (<[n := canon :: nil]> a) asserts dups
+      | Some canon' => k s t ga (<[n := canon :: canon']> a) asserts dups
       end.
 
   Definition _global_alias (canon : name) : t :=
-    fun s t ga a dups k => k s t (canon :: ga) a dups.
+    fun s t ga a asserts dups k => k s t (canon :: ga) a asserts dups.
+
+  Definition _static_assert (msg : option PrimString.string) (e : Expr) : t :=
+    let msg := match msg with
+               | Some msg => msg
+               | None => ""%pstring
+               end in
+    fun s t ga a asserts dups k =>
+      k s t ga a (Build_StaticAssert msg e :: asserts) dups.
 
   (** Constructs an empty [translation_unit.t]. *)
   Definition _skip : t :=
-    fun s t ga a dups k => k s t ga a dups.
+    fun s t ga a asserts dups k => k s t ga a asserts dups.
 
   Fixpoint array_fold {A B}
     (f : A -> B -> B) (ar : PArray.array A) (fuel : nat) (i : PrimInt63.int) (acc : B) : B :=
@@ -138,17 +171,19 @@ Module Import translation_unit.
     end.
 
   Definition decls' (ds : PArray.array t) : t :=
-    array_fold (fun (X Y : t) s t ga a dups K => X s t ga a dups (fun s t ga a dups => Y s t ga a dups K))
+    array_fold (fun (X Y : t) s t ga a asserts dups K =>
+                  X s t ga a asserts dups (fun s t ga a asserts dups => Y s t ga a asserts dups K))
       ds
       (Z.to_nat (Uint63.to_Z (PArray.length ds))) 0%uint63
-      (fun s t ga a dups k => k s t ga a dups).
+      (fun s t ga a asserts dups k => k s t ga a asserts dups).
 
   Definition decls (ds : PArray.array t) (info : abi.t) : translation_unit * dup_info :=
-    decls' ds ∅ ∅ [] ∅ [] $ fun s t ga a => pair {|
+    decls' ds ∅ ∅ [] ∅ [] [] $ fun s t ga a asserts => pair {|
       symbols := NM.from_raw s;
       types := NM.from_raw t;
       namespace_aliases := (Listset (sort.sort ga), NM.from_raw $ NM.Raw.map (fun x => Listset $ sort.sort x) a);
       initializer := nil;	(** TODO *)
+      asserts := sort_static_assert.sort asserts;
       abi := info;
     |}.
 
@@ -233,7 +268,7 @@ Definition Dglobal_using_namespace (alias : name) : K :=
   _global_alias alias.
 
 Definition Dstatic_assert (msg : option PrimString.string) (e : Expr) : K :=
-  _skip.
+  _static_assert msg e.
 
 Definition Oimplicit_default_ctor (n : globname) : K :=
   let ctor := Oconstructor

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/sub_module.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/sub_module.v
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2020-2024 BlueRock Security, Inc.
+ * Copyright (c) 2020-2026 BlueRock Security, Inc.
  * This software is distributed under the terms of the BedRock Open-Source License.
  * See the LICENSE-BedRock file in the repository root for details.
  *)
@@ -486,11 +486,26 @@ Lemma complete_type_respects_sub_table te1 te2 t :
   complete_type te2 t → complete_type te1 t.
 Proof. intros. by eapply complete_respects_sub_table_mut. Qed.
 
+(** ** Inclusion of [static_assert] *)
+Definition asserts_le (sa1 sa2 : list StaticAssert) : Prop :=
+  List.Forall (fun x => x ∈ sa2) sa1.
+
+#[global] Instance: PreOrder asserts_le.
+Proof.
+  constructor.
+  { red. intros. red. apply Forall_forall. done. }
+  { red; intros.
+    apply Forall_forall; intros.
+    eapply Forall_forall in H; eauto.
+    eapply Forall_forall in H0; eauto. }
+Qed.
+
 (** ** Inclusion on [translation_unit] *)
 
 Record sub_module (a b : translation_unit) : Prop :=
 { types_compat : type_table_le a.(types) b.(types)
 ; syms_compat : sym_table_le a.(symbols) b.(symbols)
+; asserts_compat : asserts_le a.(asserts) b.(asserts)
 ; abi_compat : a.(abi) = b.(abi) }.
 
 Section sub_module.
@@ -512,16 +527,19 @@ Definition module_le (a b : translation_unit) : bool :=
   Eval cbv beta iota zeta delta [ andb ] in
   bool_decide (a.(abi) = b.(abi)) &&
   bool_decide (type_table_le a.(types) b.(types)) &&
-  bool_decide (sym_table_le a.(symbols) b.(symbols)).
+  bool_decide (sym_table_le a.(symbols) b.(symbols)) &&
+  bool_decide (asserts_le a.(asserts) b.(asserts)).
 
-Theorem module_le_sound : forall a b, if module_le a b then
-                                   sub_module a b
-                                 else
-                                   ~sub_module a b.
+Theorem module_le_sound : forall a b,
+    if module_le a b then
+      sub_module a b
+    else
+      ~sub_module a b.
 Proof.
   rewrite /module_le; intros.
   repeat case_bool_decide.
   { constructor; eauto. }
+  { intro C; inversion C; eauto. }
   { intro C; inversion C; eauto. }
   { intro C; inversion C; eauto. }
   { intro C; inversion C; eauto. }

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/types.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/types.v
@@ -129,12 +129,12 @@ Proof.
   - rewrite /glob_def. move: Hle => [[ /(_ gn) Hle _ _]].
     revert Hle.
     case: (types (genv_tu x) !! gn); simpl; try constructor.
-    move => ? /(_ _ eq_refl) [g2 [-> HH]] /=.
+    move => ? /(_ _ eq_refl) [g2 [-> HH]] * /=.
     exact: proper_GlobDecl_size_of.
   - rewrite /glob_def. move: Hle => [[ /(_ gn) Hle _ _]].
     revert Hle.
     case: (types (genv_tu x) !! gn); simpl; try constructor.
-    move => ? /(_ _ eq_refl) [g2 [-> HH]] /=.
+    move => ? /(_ _ eq_refl) [g2 [-> HH]] * /=.
     exact: proper_GlobDecl_size_of.
   - by destruct osz; constructor.
 Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/translation_unit.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/translation_unit.v
@@ -182,6 +182,15 @@ Definition InitializerBlock : Set :=
 #[global] Instance InitializerBlock_empty : Empty InitializerBlock :=
   nil.
 
+(** ** Static assertions *)
+
+Record StaticAssert : Set := Build_StaticAssert
+  { sa_message : PrimString.string
+  ; sa_condition : Expr
+  }.
+#[global] Instance StaticAssert_eq : EqDecision StaticAssert.
+Proof. solve_decision. Defined.
+
 (** ** Aliases *)
 
 (** These support
@@ -271,6 +280,7 @@ Record translation_unit : Type := makeTranslationUnit {
   types             : type_table;
   namespace_aliases : alias_table.t;
   initializer       : InitializerBlock;
+  asserts           : list StaticAssert;
   abi               : abi.t;
 }.
 #[only(lens)] derive translation_unit.
@@ -283,7 +293,7 @@ Definition language_version (tu : translation_unit) : lang_version.t :=
 
 (** Just for testing *)
 Definition empty_tu (info : abi.t) : translation_unit :=
-  makeTranslationUnit ∅ ∅ ∅ [] info.
+  makeTranslationUnit ∅ ∅ ∅ [] [] info.
 #[global] Instance : Empty translation_unit :=
   empty_tu abi.abi_default.
 


### PR DESCRIPTION
This provides this information to users and (I predict) will be very useful when working with architecture-independent proofs.