### PR TITLE
Improve floating point support

### DIFF
--- a/rocq-skylabs-brick/tests/float_simple_pred_support.v
+++ b/rocq-skylabs-brick/tests/float_simple_pred_support.v
@@ -1,0 +1,103 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import Stdlib.ZArith.BinInt.
+Require Import Stdlib.micromega.Lia.
+Require Import skylabs.lang.cpp.syntax.
+Require Import skylabs.lang.cpp.semantics.genv.
+Require Import skylabs.lang.cpp.semantics.values.
+Require Import skylabs.lang.cpp.model.simple_pred.
+
+Open Scope Z_scope.
+
+Import SimpleCPP.
+
+Definition f16_one_bits : Z := 15360%Z.
+Definition f32_one_bits : Z := 1065353216%Z.
+Definition f128_one_bits : Z :=
+  85065399433376081038215121361612832768%Z.
+
+Definition f16_one : float_type.car float_type.Ffloat16 :=
+  float_value.of_bits float_type.Ffloat16 f16_one_bits.
+Definition f32_one : float_type.car float_type.Ffloat :=
+  float_value.of_bits float_type.Ffloat f32_one_bits.
+Definition f128_one : float_type.car float_type.Ffloat128 :=
+  float_value.of_bits float_type.Ffloat128 f128_one_bits.
+
+Section pure_encoding_tests.
+  Context `{Σ : cpp_logic} {σ : genv}.
+
+  Example pure_encodes_float16_one :
+    pure_encodes Tfloat16 (VALUES_DEFS_IMPL.Vfloat float_type.Ffloat16 f16_one)
+      (Z_to_bytes bitsize.W16 Unsigned f16_one_bits).
+  Proof.
+    rewrite /pure_encodes /=.
+    split; [reflexivity|].
+    split.
+    - replace (float_value.to_bits float_type.Ffloat16 f16_one) with f16_one_bits.
+      + rewrite /in_Z_to_bytes_bounds /f16_one_bits /=.
+        change (0 <= 15360 /\ 15360 < 65536)%Z. lia.
+      + symmetry. apply float_value.to_of_bits. change (0 <= 15360 < 65536)%Z. lia.
+    - reflexivity.
+  Qed.
+
+  Example pure_encodes_float32_one :
+    pure_encodes Tfloat (VALUES_DEFS_IMPL.Vfloat float_type.Ffloat f32_one)
+      (Z_to_bytes bitsize.W32 Unsigned f32_one_bits).
+  Proof.
+    rewrite /pure_encodes /=.
+    split; [reflexivity|].
+    split.
+    - replace (float_value.to_bits float_type.Ffloat f32_one) with f32_one_bits.
+      + rewrite /in_Z_to_bytes_bounds /f32_one_bits /=.
+        change (0 <= 1065353216 /\ 1065353216 < 4294967296)%Z. lia.
+      + symmetry. apply float_value.to_of_bits.
+        change (0 <= 1065353216 < 4294967296)%Z. lia.
+    - reflexivity.
+  Qed.
+
+  Example pure_encodes_float128_one :
+    pure_encodes Tfloat128 (VALUES_DEFS_IMPL.Vfloat float_type.Ffloat128 f128_one)
+      (Z_to_bytes bitsize.W128 Unsigned f128_one_bits).
+  Proof.
+    rewrite /pure_encodes /=.
+    split; [reflexivity|].
+    split.
+    - replace (float_value.to_bits float_type.Ffloat128 f128_one) with f128_one_bits.
+      + rewrite /in_Z_to_bytes_bounds /f128_one_bits /=.
+        change (0 <= 85065399433376081038215121361612832768 /\
+                85065399433376081038215121361612832768 <
+                340282366920938463463374607431768211456)%Z.
+        lia.
+      + symmetry.
+        apply float_value.to_of_bits.
+        change (0 <= 85065399433376081038215121361612832768 <
+                340282366920938463463374607431768211456)%Z.
+        lia.
+    - reflexivity.
+  Qed.
+
+  Example pure_encodes_float16_undef_length vs :
+    pure_encodes Tfloat16 VALUES_DEFS_IMPL.Vundef vs -> length vs = 2%nat.
+  Proof.
+    intro Henc.
+    exact (length_encodes Tfloat16 VALUES_DEFS_IMPL.Vundef vs Henc).
+  Qed.
+
+  Example pure_encodes_float128_undef_length vs :
+    pure_encodes Tfloat128 VALUES_DEFS_IMPL.Vundef vs -> length vs = 16%nat.
+  Proof.
+    intro Henc.
+    exact (length_encodes Tfloat128 VALUES_DEFS_IMPL.Vundef vs Henc).
+  Qed.
+
+  Example pure_encodes_float16_rejects_float128_value vs :
+    ~ pure_encodes Tfloat16 (VALUES_DEFS_IMPL.Vfloat float_type.Ffloat128 f128_one) vs.
+  Proof.
+    rewrite /pure_encodes /=.
+    intros (Hft & _).
+    discriminate Hft.
+  Qed.
+End pure_encoding_tests.

--- a/rocq-skylabs-brick/tests/float_support.v
+++ b/rocq-skylabs-brick/tests/float_support.v
@@ -91,85 +91,184 @@ Definition one_float : Expr := Efloat float_type.Ffloat f32_one.
 Definition one_double : Expr := Efloat float_type.Fdouble f64_one.
 Definition one_float128 : Expr := Efloat float_type.Ffloat128 f128_one.
 
-Example support_accepts_float_types :
-  check.type Tfloat16 = check.OK /\
-  check.type Tfloat = check.OK /\
-  check.type Tdouble = check.OK /\
+Example support_accepts_float16_type :
+  check.type Tfloat16 = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_type :
+  check.type Tfloat = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_double_type :
+  check.type Tdouble = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float128_type :
   check.type Tfloat128 = check.OK.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
 Example support_rejects_longdouble_type :
   check.type Tlongdouble = check.FAIL "unsupported floating width".
 Proof. reflexivity. Qed.
 
-Example support_accepts_float_literals :
-  check.expr one_float16 = check.OK /\
-  check.expr one_float = check.OK /\
-  check.expr one_double = check.OK /\
+Example support_accepts_float16_literal :
+  check.expr one_float16 = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_literal :
+  check.expr one_float = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_double_literal :
+  check.expr one_double = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float128_literal :
   check.expr one_float128 = check.OK.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
 Example support_rejects_longdouble_literal :
   check.expr (Efloat float_type.Flongdouble (float_value.zero float_type.Flongdouble)) =
     check.FAIL "unsupported floating width".
 Proof. reflexivity. Qed.
 
-Example support_accepts_float_casts :
-  check.expr (Ecast (Cfloat Tdouble) one_float) = check.OK /\
-  check.expr (Ecast (Cfloat Tfloat128) one_double) = check.OK /\
-  check.expr (Ecast (Cint2float Tfloat16) (Eint 0 Tint)) = check.OK /\
-  check.expr (Ecast (Cfloat2int Tint) one_float128) = check.OK /\
+Example support_accepts_float_to_double_cast :
+  check.expr (Ecast (Cfloat Tdouble) one_float) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_double_to_float128_cast :
+  check.expr (Ecast (Cfloat Tfloat128) one_double) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_int_to_float16_cast :
+  check.expr (Ecast (Cint2float Tfloat16) (Eint 0 Tint)) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float128_to_int_cast :
+  check.expr (Ecast (Cfloat2int Tint) one_float128) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_to_bool_cast :
   check.expr (Ecast Cfloat2bool one_float) = check.OK.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
 Definition small_enum_name : name := "Small".
 
-Example support_accepts_char_enum_float_casts :
-  check.expr (Ecast (Cint2float Tfloat) (Echar 65 Tchar)) = check.OK /\
-  check.expr (Ecast (Cfloat2int Tchar) one_float) = check.OK /\
-  check.expr (Ecast (Cint2float Tfloat) (Eenum_const small_enum_name "A")) = check.OK /\
+Example support_accepts_char_to_float_cast :
+  check.expr (Ecast (Cint2float Tfloat) (Echar 65 Tchar)) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_to_char_cast :
+  check.expr (Ecast (Cfloat2int Tchar) one_float) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_enum_to_float_cast :
+  check.expr (Ecast (Cint2float Tfloat) (Eenum_const small_enum_name "A")) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_to_enum_cast :
   check.expr (Ecast (Cfloat2int (Tenum small_enum_name)) one_float) = check.OK.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
-Example support_accepts_float_ops :
-  check.expr (Eunop Uplus one_float Tfloat) = check.OK /\
-  check.expr (Eunop Uminus one_float Tfloat) = check.OK /\
-  check.expr (Eunop Unot one_float Tbool) = check.OK /\
-  check.expr (Ebinop Badd one_float one_double Tdouble) = check.OK /\
-  check.expr (Ebinop Bsub one_float one_float Tfloat) = check.OK /\
-  check.expr (Ebinop Bmul one_float one_float Tfloat) = check.OK /\
-  check.expr (Ebinop Bdiv one_float one_float Tfloat) = check.OK /\
+Example support_accepts_float_unary_plus :
+  check.expr (Eunop Uplus one_float Tfloat) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_unary_minus :
+  check.expr (Eunop Uminus one_float Tfloat) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_logical_not :
+  check.expr (Eunop Unot one_float Tbool) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_add :
+  check.expr (Ebinop Badd one_float one_double Tdouble) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_sub :
+  check.expr (Ebinop Bsub one_float one_float Tfloat) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_mul :
+  check.expr (Ebinop Bmul one_float one_float Tfloat) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_div :
+  check.expr (Ebinop Bdiv one_float one_float Tfloat) = check.OK.
+Proof. reflexivity. Qed.
+
+Example support_accepts_float_less_than :
   check.expr (Ebinop Blt one_float one_double Tbool) = check.OK.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
-Example support_rejects_unsupported_float_ops :
-  check.expr (Ebinop Bmod one_float one_float Tfloat) <> check.OK /\
-  check.expr (Ebinop Band one_float one_float Tfloat) <> check.OK /\
-  check.expr (Ebinop Bshl one_float (Eint 1 Tint) Tfloat) <> check.OK /\
-  check.expr (Ebinop Bcmp one_float one_float Tfloat) <> check.OK /\
-  check.expr (Ebinop Badd (Evar "p" (Tptr Tint)) one_float (Tptr Tint)) <> check.OK /\
-  check.expr (Epreinc (Evar "f" Tfloat) Tfloat) <> check.OK /\
+Example support_rejects_float_mod :
+  check.expr (Ebinop Bmod one_float one_float Tfloat) <> check.OK.
+Proof. vm_compute; discriminate. Qed.
+
+Example support_rejects_float_bitand :
+  check.expr (Ebinop Band one_float one_float Tfloat) <> check.OK.
+Proof. vm_compute; discriminate. Qed.
+
+Example support_rejects_float_shift_left :
+  check.expr (Ebinop Bshl one_float (Eint 1 Tint) Tfloat) <> check.OK.
+Proof. vm_compute; discriminate. Qed.
+
+Example support_rejects_float_three_way_compare :
+  check.expr (Ebinop Bcmp one_float one_float Tfloat) <> check.OK.
+Proof. vm_compute; discriminate. Qed.
+
+Example support_rejects_pointer_float_add :
+  check.expr (Ebinop Badd (Evar "p" (Tptr Tint)) one_float (Tptr Tint)) <> check.OK.
+Proof. vm_compute; discriminate. Qed.
+
+Example support_rejects_float_preinc :
+  check.expr (Epreinc (Evar "f" Tfloat) Tfloat) <> check.OK.
+Proof. vm_compute; discriminate. Qed.
+
+Example support_rejects_float_postdec :
   check.expr (Epostdec (Evar "f" Tfloat) Tfloat) <> check.OK.
-Proof. repeat split; vm_compute; discriminate. Qed.
+Proof. vm_compute; discriminate. Qed.
 
-Example usual_float_arith_examples tu :
-  usual_float_arith tu Tfloat16 Tfloat = Some Tfloat /\
-  usual_float_arith tu Tfloat Tdouble = Some Tdouble /\
+Example usual_float_arith_float16_float tu :
+  usual_float_arith tu Tfloat16 Tfloat = Some Tfloat.
+Proof. reflexivity. Qed.
+
+Example usual_float_arith_float_double tu :
+  usual_float_arith tu Tfloat Tdouble = Some Tdouble.
+Proof. reflexivity. Qed.
+
+Example usual_float_arith_float128_double tu :
   usual_float_arith tu Tfloat128 Tdouble = Some Tfloat128.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
-Example usual_float_arith_rejects_longdouble tu :
-  usual_float_arith tu Tlongdouble Tdouble = None /\
+Example usual_float_arith_rejects_longdouble_double tu :
+  usual_float_arith tu Tlongdouble Tdouble = None.
+Proof. reflexivity. Qed.
+
+Example usual_float_arith_rejects_double_longdouble tu :
   usual_float_arith tu Tdouble Tlongdouble = None.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
-Example convert_type_float_examples tu :
-  convert_type_op tu Badd Tfloat Tdouble = Some (Tdouble, Tdouble, Tdouble) /\
-  convert_type_op tu Badd Tfloat Tint = Some (Tfloat, Tfloat, Tfloat) /\
-  convert_type_op tu Bge Tint Tdouble = Some (Tdouble, Tdouble, Tbool) /\
-  convert_type_op tu Bmod Tfloat Tfloat = None /\
+Example convert_type_float_add_promotes_to_double tu :
+  convert_type_op tu Badd Tfloat Tdouble = Some (Tdouble, Tdouble, Tdouble).
+Proof. reflexivity. Qed.
+
+Example convert_type_float_int_add_converts_int tu :
+  convert_type_op tu Badd Tfloat Tint = Some (Tfloat, Tfloat, Tfloat).
+Proof. reflexivity. Qed.
+
+Example convert_type_int_double_ge_converts_int tu :
+  convert_type_op tu Bge Tint Tdouble = Some (Tdouble, Tdouble, Tbool).
+Proof. reflexivity. Qed.
+
+Example convert_type_rejects_float_mod tu :
+  convert_type_op tu Bmod Tfloat Tfloat = None.
+Proof. reflexivity. Qed.
+
+Example convert_type_rejects_pointer_float_add tu :
   convert_type_op tu Badd (Tptr Tint) Tfloat = None.
-Proof. repeat split; reflexivity. Qed.
+Proof. reflexivity. Qed.
 
 Example convert_includes_conv_float_for_float_to_int {σ : genv} tu v v' :
   conv_float tu Tfloat Tint v v' -> @convert σ tu Tfloat Tint v v'.
@@ -215,21 +314,45 @@ Example default_float128_zero :
   get_default Tfloat128 = Some (Vfloat float_type.Ffloat128 (float_value.zero float_type.Ffloat128)).
 Proof. reflexivity. Qed.
 
-Example float_bool_zero_cases :
-  is_true (Vfloat float_type.Ffloat (float_value.zero float_type.Ffloat)) = Some false /\
-  is_true (Vfloat float_type.Ffloat f32_neg_zero) = Some false /\
-  is_true (Vfloat float_type.Ffloat f32_one) = Some true /\
-  is_true (Vfloat float_type.Ffloat f32_inf) = Some true /\
-  is_true (Vfloat float_type.Ffloat f32_nan) = Some true.
-Proof. repeat split; vm_compute; reflexivity. Qed.
+Example float_zero_is_false :
+  is_true (Vfloat float_type.Ffloat (float_value.zero float_type.Ffloat)) = Some false.
+Proof. vm_compute; reflexivity. Qed.
 
-Example float16_and_float128_bool_cases :
-  is_true (Vfloat float_type.Ffloat16 f16_neg_zero) = Some false /\
-  is_true (Vfloat float_type.Ffloat16 f16_one) = Some true /\
-  is_true (Vfloat float_type.Ffloat128 f128_neg_zero) = Some false /\
-  is_true (Vfloat float_type.Ffloat128 f128_inf) = Some true /\
+Example float_negative_zero_is_false :
+  is_true (Vfloat float_type.Ffloat f32_neg_zero) = Some false.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float_one_is_true :
+  is_true (Vfloat float_type.Ffloat f32_one) = Some true.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float_infinity_is_true :
+  is_true (Vfloat float_type.Ffloat f32_inf) = Some true.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float_nan_is_true :
+  is_true (Vfloat float_type.Ffloat f32_nan) = Some true.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float16_negative_zero_is_false :
+  is_true (Vfloat float_type.Ffloat16 f16_neg_zero) = Some false.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float16_one_is_true :
+  is_true (Vfloat float_type.Ffloat16 f16_one) = Some true.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float128_negative_zero_is_false :
+  is_true (Vfloat float_type.Ffloat128 f128_neg_zero) = Some false.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float128_infinity_is_true :
+  is_true (Vfloat float_type.Ffloat128 f128_inf) = Some true.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float128_nan_is_true :
   is_true (Vfloat float_type.Ffloat128 f128_nan) = Some true.
-Proof. repeat split; vm_compute; reflexivity. Qed.
+Proof. vm_compute; reflexivity. Qed.
 
 Example eval_not_float_zero {σ : genv} tu :
   eval_unop tu Unot Tfloat Tbool
@@ -237,7 +360,7 @@ Example eval_not_float_zero {σ : genv} tu :
     (Vbool true).
 Proof.
   replace true with
-    (negb (float_value.is_true float_type.Ffloat (float_value.zero float_type.Ffloat))).
+    (negb (@float_value.is_true float_type.Ffloat (float_value.zero float_type.Ffloat))).
   - apply eval_not_float.
   - rewrite float_value.is_true_zero. reflexivity.
 Qed.
@@ -247,7 +370,7 @@ Example eval_not_float_nan {σ : genv} tu :
     (Vfloat float_type.Ffloat f32_nan)
     (Vbool false).
 Proof.
-  replace false with (negb (float_value.is_true float_type.Ffloat f32_nan)).
+  replace false with (negb (@float_value.is_true float_type.Ffloat f32_nan)).
   - apply eval_not_float.
   - vm_compute; reflexivity.
 Qed.
@@ -278,23 +401,41 @@ Example float_to_char_accepts_representable_char :
     (float_value.of_int float_type.Ffloat 65) = Some 65%N.
 Proof. vm_compute; reflexivity. Qed.
 
-Example raw_float_intro_examples {σ : genv} :
+Example raw_float16_intro {σ : genv} :
   raw_bytes_of_val σ Tfloat16 (Vfloat float_type.Ffloat16 f16_one)
-    (float_raw_bytes σ float_type.Ffloat16 f16_one) /\
+    (float_raw_bytes σ float_type.Ffloat16 f16_one).
+Proof. apply raw_bytes_of_val_float_intro. Qed.
+
+Example raw_float_intro {σ : genv} :
   raw_bytes_of_val σ Tfloat (Vfloat float_type.Ffloat f32_one)
-    (float_raw_bytes σ float_type.Ffloat f32_one) /\
+    (float_raw_bytes σ float_type.Ffloat f32_one).
+Proof. apply raw_bytes_of_val_float_intro. Qed.
+
+Example raw_double_intro {σ : genv} :
   raw_bytes_of_val σ Tdouble (Vfloat float_type.Fdouble f64_one)
-    (float_raw_bytes σ float_type.Fdouble f64_one) /\
+    (float_raw_bytes σ float_type.Fdouble f64_one).
+Proof. apply raw_bytes_of_val_float_intro. Qed.
+
+Example raw_float128_intro {σ : genv} :
   raw_bytes_of_val σ Tfloat128 (Vfloat float_type.Ffloat128 f128_one)
     (float_raw_bytes σ float_type.Ffloat128 f128_one).
-Proof. repeat split; apply raw_bytes_of_val_float_intro. Qed.
+Proof. apply raw_bytes_of_val_float_intro. Qed.
 
-Example float_bits_compatible_examples :
-  float_bits_compatible int_rank.Ishort float_type.Ffloat16 /\
-  float_bits_compatible int_rank.Iint float_type.Ffloat /\
-  float_bits_compatible int_rank.Ilong float_type.Fdouble /\
+Example float16_bits_compatible :
+  float_bits_compatible int_rank.Ishort float_type.Ffloat16.
+Proof. split; reflexivity. Qed.
+
+Example float32_bits_compatible :
+  float_bits_compatible int_rank.Iint float_type.Ffloat.
+Proof. split; reflexivity. Qed.
+
+Example double_bits_compatible :
+  float_bits_compatible int_rank.Ilong float_type.Fdouble.
+Proof. split; reflexivity. Qed.
+
+Example float128_bits_compatible :
   float_bits_compatible int_rank.I128 float_type.Ffloat128.
-Proof. repeat split; split; reflexivity. Qed.
+Proof. split; reflexivity. Qed.
 
 Example longdouble_raw_bits_not_binary128_compatible :
   ~ float_bits_compatible int_rank.I128 float_type.Flongdouble.

--- a/rocq-skylabs-brick/tests/float_support.v
+++ b/rocq-skylabs-brick/tests/float_support.v
@@ -230,26 +230,6 @@ Example support_rejects_float_postdec :
   check.expr (Epostdec (Evar "f" Tfloat) Tfloat) <> check.OK.
 Proof. vm_compute; discriminate. Qed.
 
-Example usual_float_arith_float16_float tu :
-  usual_float_arith tu Tfloat16 Tfloat = Some Tfloat.
-Proof. reflexivity. Qed.
-
-Example usual_float_arith_float_double tu :
-  usual_float_arith tu Tfloat Tdouble = Some Tdouble.
-Proof. reflexivity. Qed.
-
-Example usual_float_arith_float128_double tu :
-  usual_float_arith tu Tfloat128 Tdouble = Some Tfloat128.
-Proof. reflexivity. Qed.
-
-Example usual_float_arith_rejects_longdouble_double tu :
-  usual_float_arith tu Tlongdouble Tdouble = None.
-Proof. reflexivity. Qed.
-
-Example usual_float_arith_rejects_double_longdouble tu :
-  usual_float_arith tu Tdouble Tlongdouble = None.
-Proof. reflexivity. Qed.
-
 Example convert_type_float_add_promotes_to_double tu :
   convert_type_op tu Badd Tfloat Tdouble = Some (Tdouble, Tdouble, Tdouble).
 Proof. reflexivity. Qed.

--- a/rocq-skylabs-brick/tests/float_support.v
+++ b/rocq-skylabs-brick/tests/float_support.v
@@ -1,0 +1,296 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import Stdlib.ZArith.BinInt.
+Require Import Stdlib.micromega.Lia.
+Require Import skylabs.lang.cpp.syntax.
+Require Import skylabs.lang.cpp.syntax.supported.
+Require Import skylabs.lang.cpp.semantics.genv.
+Require Import skylabs.lang.cpp.semantics.values.
+Require Import skylabs.lang.cpp.semantics.cast.
+Require Import skylabs.lang.cpp.semantics.cast_operator.
+Require Import skylabs.lang.cpp.semantics.operator.
+Require Import skylabs.lang.cpp.logic.raw.
+
+Open Scope pstring_scope.
+Open Scope Z_scope.
+
+Definition f16_one_bits : Z := 15360%Z.
+Definition f16_neg_zero_bits : Z := 32768%Z.
+Definition f16_inf_bits : Z := 31744%Z.
+Definition f16_nan_payload_bits : Z := 32257%Z.
+
+Definition f32_one_bits : Z := 1065353216%Z.
+Definition f32_neg_zero_bits : Z := 2147483648%Z.
+Definition f32_inf_bits : Z := 2139095040%Z.
+Definition f32_nan_payload_bits : Z := 2143289345%Z.
+
+Definition f64_one_bits : Z := 4607182418800017408%Z.
+Definition f64_neg_zero_bits : Z := 9223372036854775808%Z.
+Definition f64_inf_bits : Z := 9218868437227405312%Z.
+Definition f64_nan_payload_bits : Z := 9221120237041090561%Z.
+
+Definition f128_one_bits : Z :=
+  85065399433376081038215121361612832768%Z.
+Definition f128_neg_zero_bits : Z :=
+  170141183460469231731687303715884105728%Z.
+Definition f128_inf_bits : Z :=
+  170135991163610696904058773219554885632%Z.
+Definition f128_nan_payload_bits : Z :=
+  170138587312039964317873038467719495681%Z.
+
+Definition f16_one : float_type.car float_type.Ffloat16 :=
+  float_value.of_bits float_type.Ffloat16 f16_one_bits.
+Definition f32_one : float_type.car float_type.Ffloat :=
+  float_value.of_bits float_type.Ffloat f32_one_bits.
+Definition f64_one : float_type.car float_type.Fdouble :=
+  float_value.of_bits float_type.Fdouble f64_one_bits.
+Definition f128_one : float_type.car float_type.Ffloat128 :=
+  float_value.of_bits float_type.Ffloat128 f128_one_bits.
+
+Definition f16_neg_zero : float_type.car float_type.Ffloat16 :=
+  float_value.of_bits float_type.Ffloat16 f16_neg_zero_bits.
+Definition f32_neg_zero : float_type.car float_type.Ffloat :=
+  float_value.of_bits float_type.Ffloat f32_neg_zero_bits.
+Definition f64_neg_zero : float_type.car float_type.Fdouble :=
+  float_value.of_bits float_type.Fdouble f64_neg_zero_bits.
+Definition f128_neg_zero : float_type.car float_type.Ffloat128 :=
+  float_value.of_bits float_type.Ffloat128 f128_neg_zero_bits.
+
+Definition f16_inf : float_type.car float_type.Ffloat16 :=
+  float_value.of_bits float_type.Ffloat16 f16_inf_bits.
+Definition f32_inf : float_type.car float_type.Ffloat :=
+  float_value.of_bits float_type.Ffloat f32_inf_bits.
+Definition f64_inf : float_type.car float_type.Fdouble :=
+  float_value.of_bits float_type.Fdouble f64_inf_bits.
+Definition f128_inf : float_type.car float_type.Ffloat128 :=
+  float_value.of_bits float_type.Ffloat128 f128_inf_bits.
+
+Definition f16_nan : float_type.car float_type.Ffloat16 :=
+  proj1_sig (float_value.default_nan float_type.Ffloat16).
+Definition f32_nan : float_type.car float_type.Ffloat :=
+  proj1_sig (float_value.default_nan float_type.Ffloat).
+Definition f64_nan : float_type.car float_type.Fdouble :=
+  proj1_sig (float_value.default_nan float_type.Fdouble).
+Definition f128_nan : float_type.car float_type.Ffloat128 :=
+  proj1_sig (float_value.default_nan float_type.Ffloat128).
+
+Definition f16_nan_payload : float_type.car float_type.Ffloat16 :=
+  float_value.of_bits float_type.Ffloat16 f16_nan_payload_bits.
+Definition f32_nan_payload : float_type.car float_type.Ffloat :=
+  float_value.of_bits float_type.Ffloat f32_nan_payload_bits.
+Definition f64_nan_payload : float_type.car float_type.Fdouble :=
+  float_value.of_bits float_type.Fdouble f64_nan_payload_bits.
+Definition f128_nan_payload : float_type.car float_type.Ffloat128 :=
+  float_value.of_bits float_type.Ffloat128 f128_nan_payload_bits.
+
+Definition one_float16 : Expr := Efloat float_type.Ffloat16 f16_one.
+Definition one_float : Expr := Efloat float_type.Ffloat f32_one.
+Definition one_double : Expr := Efloat float_type.Fdouble f64_one.
+Definition one_float128 : Expr := Efloat float_type.Ffloat128 f128_one.
+
+Example support_accepts_float_types :
+  check.type Tfloat16 = check.OK /\
+  check.type Tfloat = check.OK /\
+  check.type Tdouble = check.OK /\
+  check.type Tlongdouble = check.OK /\
+  check.type Tfloat128 = check.OK.
+Proof. repeat split; reflexivity. Qed.
+
+Example support_accepts_float_literals :
+  check.expr one_float16 = check.OK /\
+  check.expr one_float = check.OK /\
+  check.expr one_double = check.OK /\
+  check.expr one_float128 = check.OK.
+Proof. repeat split; reflexivity. Qed.
+
+Example support_accepts_float_casts :
+  check.expr (Ecast (Cfloat Tdouble) one_float) = check.OK /\
+  check.expr (Ecast (Cfloat Tfloat128) one_double) = check.OK /\
+  check.expr (Ecast (Cint2float Tfloat16) (Eint 0 Tint)) = check.OK /\
+  check.expr (Ecast (Cfloat2int Tint) one_float128) = check.OK /\
+  check.expr (Ecast Cfloat2bool one_float) = check.OK.
+Proof. repeat split; reflexivity. Qed.
+
+Definition small_enum_name : name := "Small".
+
+Example support_accepts_char_enum_float_casts :
+  check.expr (Ecast (Cint2float Tfloat) (Echar 65 Tchar)) = check.OK /\
+  check.expr (Ecast (Cfloat2int Tchar) one_float) = check.OK /\
+  check.expr (Ecast (Cint2float Tfloat) (Eenum_const small_enum_name "A")) = check.OK /\
+  check.expr (Ecast (Cfloat2int (Tenum small_enum_name)) one_float) = check.OK.
+Proof. repeat split; reflexivity. Qed.
+
+Example support_accepts_float_ops :
+  check.expr (Eunop Uplus one_float Tfloat) = check.OK /\
+  check.expr (Eunop Uminus one_float Tfloat) = check.OK /\
+  check.expr (Eunop Unot one_float Tbool) = check.OK /\
+  check.expr (Ebinop Badd one_float one_double Tdouble) = check.OK /\
+  check.expr (Ebinop Bsub one_float one_float Tfloat) = check.OK /\
+  check.expr (Ebinop Bmul one_float one_float Tfloat) = check.OK /\
+  check.expr (Ebinop Bdiv one_float one_float Tfloat) = check.OK /\
+  check.expr (Ebinop Blt one_float one_double Tbool) = check.OK.
+Proof. repeat split; reflexivity. Qed.
+
+Example support_rejects_unsupported_float_ops :
+  check.expr (Ebinop Bmod one_float one_float Tfloat) <> check.OK /\
+  check.expr (Ebinop Band one_float one_float Tfloat) <> check.OK /\
+  check.expr (Ebinop Bshl one_float (Eint 1 Tint) Tfloat) <> check.OK /\
+  check.expr (Ebinop Bcmp one_float one_float Tfloat) <> check.OK /\
+  check.expr (Ebinop Badd (Evar "p" (Tptr Tint)) one_float (Tptr Tint)) <> check.OK /\
+  check.expr (Epreinc (Evar "f" Tfloat) Tfloat) <> check.OK /\
+  check.expr (Epostdec (Evar "f" Tfloat) Tfloat) <> check.OK.
+Proof. repeat split; vm_compute; discriminate. Qed.
+
+Example usual_float_arith_examples tu :
+  usual_float_arith tu Tfloat16 Tfloat = Some Tfloat /\
+  usual_float_arith tu Tfloat Tdouble = Some Tdouble /\
+  usual_float_arith tu Tfloat128 Tdouble = Some Tfloat128.
+Proof. repeat split; reflexivity. Qed.
+
+Example convert_type_float_examples tu :
+  convert_type_op tu Badd Tfloat Tdouble = Some (Tdouble, Tdouble, Tdouble) /\
+  convert_type_op tu Badd Tfloat Tint = Some (Tfloat, Tfloat, Tfloat) /\
+  convert_type_op tu Bge Tint Tdouble = Some (Tdouble, Tdouble, Tbool) /\
+  convert_type_op tu Bmod Tfloat Tfloat = None /\
+  convert_type_op tu Badd (Tptr Tint) Tfloat = None.
+Proof. repeat split; reflexivity. Qed.
+
+Example convert_includes_conv_float_for_float_to_int {σ : genv} tu v v' :
+  conv_float tu Tfloat Tint v v' -> @convert σ tu Tfloat Tint v v'.
+Proof. intros Hconv. rewrite /convert /=. by right. Qed.
+
+Example has_type_prop_float_value {σ : genv} :
+  has_type_prop (Vfloat float_type.Ffloat f32_one) Tfloat.
+Proof. apply has_float_type. Qed.
+
+Example has_type_prop_rejects_mismatched_float {σ : genv} :
+  ~ has_type_prop (Vfloat float_type.Ffloat f32_one) Tdouble.
+Proof.
+  intros Hty.
+  rewrite has_type_prop_float in Hty.
+  destruct Hty as [f Hf]. discriminate Hf.
+Qed.
+
+Example float_to_of_bits_roundtrips bits :
+  (0 <= bits < 2 ^ float_type.bit_width float_type.Ffloat)%Z ->
+  float_value.to_bits float_type.Ffloat
+    (float_value.of_bits float_type.Ffloat bits) = bits.
+Proof. apply float_value.to_of_bits. Qed.
+
+Example double_of_to_bits_roundtrip f :
+  float_value.of_bits float_type.Fdouble
+    (float_value.to_bits float_type.Fdouble f) = f.
+Proof. apply float_value.of_to_bits. Qed.
+
+Example float128_nan_payload_bits_preserved :
+  float_value.to_bits float_type.Ffloat128 f128_nan_payload = f128_nan_payload_bits.
+Proof.
+  apply float_value.to_of_bits.
+  change (0 <= 170138587312039964317873038467719495681 <
+          340282366920938463463374607431768211456)%Z.
+  lia.
+Qed.
+
+Example default_float_zero :
+  get_default Tfloat = Some (Vfloat float_type.Ffloat (float_value.zero float_type.Ffloat)).
+Proof. reflexivity. Qed.
+
+Example default_float128_zero :
+  get_default Tfloat128 = Some (Vfloat float_type.Ffloat128 (float_value.zero float_type.Ffloat128)).
+Proof. reflexivity. Qed.
+
+Example float_bool_zero_cases :
+  is_true (Vfloat float_type.Ffloat (float_value.zero float_type.Ffloat)) = Some false /\
+  is_true (Vfloat float_type.Ffloat f32_neg_zero) = Some false /\
+  is_true (Vfloat float_type.Ffloat f32_one) = Some true /\
+  is_true (Vfloat float_type.Ffloat f32_inf) = Some true /\
+  is_true (Vfloat float_type.Ffloat f32_nan) = Some true.
+Proof. repeat split; vm_compute; reflexivity. Qed.
+
+Example float16_and_float128_bool_cases :
+  is_true (Vfloat float_type.Ffloat16 f16_neg_zero) = Some false /\
+  is_true (Vfloat float_type.Ffloat16 f16_one) = Some true /\
+  is_true (Vfloat float_type.Ffloat128 f128_neg_zero) = Some false /\
+  is_true (Vfloat float_type.Ffloat128 f128_inf) = Some true /\
+  is_true (Vfloat float_type.Ffloat128 f128_nan) = Some true.
+Proof. repeat split; vm_compute; reflexivity. Qed.
+
+Example eval_not_float_zero {σ : genv} tu :
+  eval_unop tu Unot Tfloat Tbool
+    (Vfloat float_type.Ffloat (float_value.zero float_type.Ffloat))
+    (Vbool true).
+Proof.
+  replace true with
+    (negb (float_value.is_true float_type.Ffloat (float_value.zero float_type.Ffloat))).
+  - apply eval_not_float.
+  - rewrite float_value.is_true_zero. reflexivity.
+Qed.
+
+Example eval_not_float_nan {σ : genv} tu :
+  eval_unop tu Unot Tfloat Tbool
+    (Vfloat float_type.Ffloat f32_nan)
+    (Vbool false).
+Proof.
+  replace false with (negb (float_value.is_true float_type.Ffloat f32_nan)).
+  - apply eval_not_float.
+  - vm_compute; reflexivity.
+Qed.
+
+Example float_nan_compare_unordered :
+  float_value.value_compare float_type.Ffloat f32_nan f32_nan = None.
+Proof. vm_compute; reflexivity. Qed.
+
+Example double_nan_compare_unordered :
+  float_value.value_compare float_type.Fdouble f64_nan f64_nan = None.
+Proof. vm_compute; reflexivity. Qed.
+
+Example float_nan_payload_add_preserved :
+  float_value.to_bits float_type.Ffloat
+    (float_value.add float_type.Ffloat f32_nan_payload f32_one) =
+  f32_nan_payload_bits.
+Proof. vm_compute; reflexivity. Qed.
+
+Definition little_float_test_genv : genv :=
+  {| genv_tu := empty_tu (abi.mkT int_rank.Ilong Signed Signed Little lang_version.Cpp20) |}.
+
+Example char32_to_float_uses_full_unsigned_range :
+  char_to_Z_for_float little_float_test_genv char_type.C32 65535 = 65535%Z.
+Proof. rewrite /char_to_Z_for_float of_char.unlock. reflexivity. Qed.
+
+Example float_to_char_accepts_representable_char :
+  float_to_char little_float_test_genv float_type.Ffloat char_type.C8
+    (float_value.of_int float_type.Ffloat 65) = Some 65%N.
+Proof. vm_compute; reflexivity. Qed.
+
+Example raw_float_intro_examples {σ : genv} :
+  raw_bytes_of_val σ Tfloat16 (Vfloat float_type.Ffloat16 f16_one)
+    (float_raw_bytes σ float_type.Ffloat16 f16_one) /\
+  raw_bytes_of_val σ Tfloat (Vfloat float_type.Ffloat f32_one)
+    (float_raw_bytes σ float_type.Ffloat f32_one) /\
+  raw_bytes_of_val σ Tdouble (Vfloat float_type.Fdouble f64_one)
+    (float_raw_bytes σ float_type.Fdouble f64_one) /\
+  raw_bytes_of_val σ Tfloat128 (Vfloat float_type.Ffloat128 f128_one)
+    (float_raw_bytes σ float_type.Ffloat128 f128_one).
+Proof. repeat split; apply raw_bytes_of_val_float_intro. Qed.
+
+Example float_bits_compatible_examples :
+  float_bits_compatible int_rank.Ishort float_type.Ffloat16 /\
+  float_bits_compatible int_rank.Iint float_type.Ffloat /\
+  float_bits_compatible int_rank.Ilong float_type.Fdouble /\
+  float_bits_compatible int_rank.I128 float_type.Ffloat128.
+Proof. repeat split; split; reflexivity. Qed.
+
+Example longdouble_raw_bits_not_binary128_compatible :
+  ~ float_bits_compatible int_rank.I128 float_type.Flongdouble.
+Proof. intros [_ Hwidth]. vm_compute in Hwidth. discriminate. Qed.
+
+Example float_to_bits_has_unsigned_type {σ : genv} :
+  has_type_prop (Vint (float_value.to_bits float_type.Ffloat f32_one))
+    (Tnum int_rank.Iint Unsigned).
+Proof.
+  apply float_to_bits_has_type_unsigned.
+  split; reflexivity.
+Qed.

--- a/rocq-skylabs-brick/tests/float_support.v
+++ b/rocq-skylabs-brick/tests/float_support.v
@@ -95,9 +95,12 @@ Example support_accepts_float_types :
   check.type Tfloat16 = check.OK /\
   check.type Tfloat = check.OK /\
   check.type Tdouble = check.OK /\
-  check.type Tlongdouble = check.OK /\
   check.type Tfloat128 = check.OK.
 Proof. repeat split; reflexivity. Qed.
+
+Example support_rejects_longdouble_type :
+  check.type Tlongdouble = check.FAIL "unsupported floating width".
+Proof. reflexivity. Qed.
 
 Example support_accepts_float_literals :
   check.expr one_float16 = check.OK /\
@@ -105,6 +108,11 @@ Example support_accepts_float_literals :
   check.expr one_double = check.OK /\
   check.expr one_float128 = check.OK.
 Proof. repeat split; reflexivity. Qed.
+
+Example support_rejects_longdouble_literal :
+  check.expr (Efloat float_type.Flongdouble (float_value.zero float_type.Flongdouble)) =
+    check.FAIL "unsupported floating width".
+Proof. reflexivity. Qed.
 
 Example support_accepts_float_casts :
   check.expr (Ecast (Cfloat Tdouble) one_float) = check.OK /\
@@ -148,6 +156,11 @@ Example usual_float_arith_examples tu :
   usual_float_arith tu Tfloat16 Tfloat = Some Tfloat /\
   usual_float_arith tu Tfloat Tdouble = Some Tdouble /\
   usual_float_arith tu Tfloat128 Tdouble = Some Tfloat128.
+Proof. repeat split; reflexivity. Qed.
+
+Example usual_float_arith_rejects_longdouble tu :
+  usual_float_arith tu Tlongdouble Tdouble = None /\
+  usual_float_arith tu Tdouble Tlongdouble = None.
 Proof. repeat split; reflexivity. Qed.
 
 Example convert_type_float_examples tu :

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/raw.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/raw.v
@@ -65,6 +65,49 @@ Axiom raw_byte_of_int_eq : ∀ {σ : genv} sz x rs,
   raw_bytes_of_val σ (Tnum sz Unsigned) (Vint x) rs <->
   ∃ l, decodes_uint l x /\ raw_int_byte <$> l = rs /\ length l = N.to_nat (int_rank.bytesN sz).
 
+Lemma raw_bytes_of_val_float_intro {σ : genv} ft (f : float_type.car ft) :
+  raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) (float_raw_bytes σ ft f).
+Proof. apply raw_bytes_of_val_float. reflexivity. Qed.
+
+Lemma raw_bytes_of_val_float_elim {σ : genv} ft (f : float_type.car ft) rs :
+  raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs ->
+  rs = float_raw_bytes σ ft f.
+Proof. apply raw_bytes_of_val_float. Qed.
+
+Definition float_bits_compatible (sz : int_rank.t) (ft : float_type.t) : Prop :=
+  int_rank.bitsize sz = float_type.bitsize ft /\
+  float_type.bit_width ft = bitsize.bitsZ (float_type.bitsize ft).
+
+Lemma unsigned_bitsize_bound bs z :
+  (0 <= z < 2 ^ bitsize.bitsZ bs)%Z ->
+  bitsize.bound bs Unsigned z.
+Proof.
+  destruct bs; rewrite /bitsize.bound /bitsize.min_val /bitsize.max_val /bits_min_val /bits_max_val /=; lia.
+Qed.
+
+Lemma float_to_bits_has_type_unsigned {σ : genv} sz ft (f : float_type.car ft) :
+  float_bits_compatible sz ft ->
+  has_type_prop (Vint (float_value.to_bits ft f)) (Tnum sz Unsigned).
+Proof.
+  intros [Hbits Hwidth].
+  rewrite -has_int_type.
+  rewrite Hbits.
+  apply unsigned_bitsize_bound.
+  rewrite -Hwidth.
+  apply float_value.to_bits_range.
+Qed.
+
+(** Reverse raw-byte reinterpretation is axiomatized at this abstraction level:
+    [raw_byte] deliberately does not expose an injective byte-to-[N] view, so
+    the existing integer raw-byte characterization is not enough to reconstruct
+    the byte list needed by [float_raw_bytes].  The compatibility premise
+    excludes the current [Flongdouble] model, whose Flocq bit encoding does not
+    occupy all 16 object bytes. *)
+Axiom raw_bytes_of_val_unsigned_bits_to_float : forall {σ : genv} sz ft z rs,
+  float_bits_compatible sz ft ->
+  raw_bytes_of_val σ (Tnum sz Unsigned) (Vint z) rs ->
+  raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft (float_value.of_bits ft z)) rs.
+
 Section with_Σ.
   Context `{Σ : cpp_logic} {σ : genv}.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/model/simple_pred.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/simple_pred.v
@@ -426,7 +426,15 @@ Module SimpleCPP.
           else False
         | Tnullptr =>
           vs = cptr 0 /\ v = Vptr nullptr
-        | Tfloat_ _ => False
+        | Tfloat_ ft =>
+          match v with
+          | Vfloat ft' f =>
+              ft = ft' /\
+              in_Z_to_bytes_bounds (float_type.bitsize ft') Unsigned (float_value.to_bits ft' f) /\
+              vs = Z_to_bytes (float_type.bitsize ft') Unsigned (float_value.to_bits ft' f)
+          | Vundef => pure_encodes_undef (float_type.bitsize ft) vs
+          | _ => False
+          end
         | Tarch _ _ => False
         | Tptr _ =>
           match v with
@@ -479,6 +487,7 @@ Module SimpleCPP.
           length vs = match erase_qualifiers t with
                       | Tbool => 1
                       | Tnum sz _ => int_rank.bytesNat sz
+                      | Tfloat_ ft => bitsize.bytesNat (float_type.bitsize ft)
 
                       | Tmember_pointer _ _ | Tnullptr | Tptr _
                       | Tfunction _ | Tref _ | Trv_ref _ =>
@@ -492,8 +501,10 @@ Module SimpleCPP.
           destruct v => //; destruct_and? => //;
           repeat case_decide => //;
            simplify_eq; eauto.
-        by destruct sz.
-        erewrite length_pure_encodes_undef; eauto. by destruct sz.
+        all: try by destruct sz.
+        all: try by destruct f.
+        all: try (erewrite length_pure_encodes_undef; eauto; by destruct sz).
+        all: try (erewrite length_pure_encodes_undef; eauto; by destruct f).
       Qed.
 
       Lemma length_encodes_pos t v vs :
@@ -538,6 +549,7 @@ Module SimpleCPP.
         by [
           edestruct cptr_ne_aptr | edestruct pure_encodes_undef_aptr |
           edestruct pure_encodes_undef_Z_to_bytes |
+          f_equal; apply float_value.to_bits_inj; exact: Z_to_bytes_inj |
           f_equiv; exact: Z_to_bytes_inj ].
       Qed.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/cast.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/cast.v
@@ -251,14 +251,12 @@ Definition conv_float {σ : genv} (tu : translation_unit) (from to : type) (v v'
   | Tchar_ ct , Tfloat_ f =>
       match v with
       | Vchar n =>
-          v' = Vfloat f (float_value.of_int f
-            (of_char (char_type.bitsN ct) (signedness_of_char σ ct)
-              (int_rank.bitsN int_rank.Iint) Signed n))
+          v' = Vfloat f (float_value.of_int f (char_to_Z_for_float σ ct n))
       | _ => False
       end
   | Tfloat_ _ , Tbool =>
       match v with
-      | Vfloat f z => v' = Vbool (negb (float_value.is_zero z))
+      | Vfloat f z => v' = Vbool (float_value.is_true f z)
       | _ => False
       end
   | Tfloat_ _ , Tnum _ _ =>
@@ -273,12 +271,8 @@ Definition conv_float {σ : genv} (tu : translation_unit) (from to : type) (v v'
   | Tfloat_ _ , Tchar_ ct =>
       match v with
       | Vfloat f z =>
-          match float_value.to_int f z with
-          | Some n =>
-              v' = Vchar (to_char (int_rank.bitsN int_rank.Iint) Signed
-                (char_type.bitsN ct) n) /\
-              let int_ty := equivalent_int_type σ ct in
-              has_type_prop (Vint n) (integral_type_to_type int_ty)
+          match float_to_char σ f ct z with
+          | Some n => v' = Vchar n
           | None => False
           end
       | _ => False
@@ -319,6 +313,7 @@ Section conv_float.
             eapply has_type_prop_representation_type_not_raw => /=; try congruence; try rewrite H
         end; subst; eauto.
     all: try solve [eapply has_float_type].
+    all: try solve [eapply float_to_char_has_type; eassumption].
     all: try solve [eapply has_bool_type; case_match; lia].
     all: try solve [
       match goal with
@@ -342,6 +337,111 @@ Section conv_float.
     rewrite /conv_float.
     repeat (case_match; try tauto); intuition; try congruence.
   Qed.
+
+  Lemma conv_float_id ft (fv fv' : float_type.car ft) :
+      float_value.cast ft ft fv = Some fv' ->
+      conv_float tu (Tfloat_ ft) (Tfloat_ ft) (Vfloat ft fv) (Vfloat ft fv').
+  Proof using Hmod.
+    intros Hcast. rewrite /conv_float. cbn [representation_type drop_qualifiers erase_qualifiers].
+    split; first apply has_float_type.
+    change (match float_value.cast ft ft fv with
+            | Some z' => Vfloat ft fv' = Vfloat ft z'
+            | None => False
+            end).
+    by rewrite Hcast.
+  Qed.
+
+  Lemma conv_float_to_bool ft (fv : float_type.car ft) :
+      conv_float tu (Tfloat_ ft) Tbool (Vfloat ft fv)
+        (Vbool (float_value.is_true ft fv)).
+  Proof using Hmod.
+    rewrite /conv_float /=. split; first apply has_float_type. done.
+  Qed.
+
+  Lemma conv_float_cast from to (fv : float_type.car from) fv' :
+      float_value.cast from to fv = Some fv' ->
+      conv_float tu (Tfloat_ from) (Tfloat_ to) (Vfloat from fv) (Vfloat to fv').
+  Proof using Hmod.
+    intros Hcast. rewrite /conv_float. cbn [representation_type drop_qualifiers erase_qualifiers].
+    split; first apply has_float_type.
+    change (match float_value.cast from to fv with
+            | Some z' => Vfloat to fv' = Vfloat to z'
+            | None => False
+            end).
+    by rewrite Hcast.
+  Qed.
+
+  Lemma conv_float_int_to_float ty sz sgn ft z :
+      representation_type tu ty = Tnum sz sgn ->
+      has_type_prop (Vint z) ty ->
+      conv_float tu ty (Tfloat_ ft) (Vint z) (Vfloat ft (float_value.of_int ft z)).
+  Proof using Hmod.
+    intros Hrepr Hty. rewrite /conv_float Hrepr /=. by split.
+  Qed.
+
+  Lemma conv_float_bool_to_float ft b :
+      conv_float tu Tbool (Tfloat_ ft) (Vbool b)
+        (Vfloat ft (float_value.of_int ft (if b then 1 else 0))).
+  Proof using Hmod.
+    rewrite /conv_float /=. split.
+    - rewrite has_type_prop_bool. by eexists.
+    - by destruct b.
+  Qed.
+
+  Lemma conv_float_char_to_float ct ft n :
+      has_type_prop (Vchar n) (Tchar_ ct) ->
+      conv_float tu (Tchar_ ct) (Tfloat_ ft) (Vchar n)
+        (Vfloat ft (float_value.of_int ft (char_to_Z_for_float σ ct n))).
+  Proof using Hmod.
+    intros Hty. rewrite /conv_float /=. by split.
+  Qed.
+
+  Lemma conv_float_to_int ty sz sgn ft (fv : float_type.car ft) z :
+      representation_type tu ty = Tnum sz sgn ->
+      float_value.to_int ft fv = Some z ->
+      has_type_prop (Vint z) ty ->
+      conv_float tu (Tfloat_ ft) ty (Vfloat ft fv) (Vint z).
+  Proof using Hmod.
+    intros Hrepr Hto Hty. rewrite /conv_float Hrepr /=. split; first apply has_float_type.
+    by rewrite Hto.
+  Qed.
+
+  Lemma conv_float_to_char ft ct (fv : float_type.car ft) n :
+      float_to_char σ ft ct fv = Some n ->
+      conv_float tu (Tfloat_ ft) (Tchar_ ct) (Vfloat ft fv) (Vchar n).
+  Proof using Hmod.
+    intros Hto. rewrite /conv_float /=. split; first apply has_float_type.
+    by rewrite Hto.
+  Qed.
+
+  Lemma conv_float_enum_to_float nm sz sgn ft z :
+      representation_type tu (Tenum nm) = Tnum sz sgn ->
+      has_type_prop (Vint z) (Tenum nm) ->
+      conv_float tu (Tenum nm) (Tfloat_ ft) (Vint z)
+        (Vfloat ft (float_value.of_int ft z)).
+  Proof using Hmod.
+    intros Hrepr Hty. rewrite /conv_float Hrepr /=. by split.
+  Qed.
+
+  Lemma conv_float_to_enum nm sz sgn ft (fv : float_type.car ft) z :
+      representation_type tu (Tenum nm) = Tnum sz sgn ->
+      float_value.to_int ft fv = Some z ->
+      has_type_prop (Vint z) (Tenum nm) ->
+      conv_float tu (Tfloat_ ft) (Tenum nm) (Vfloat ft fv) (Vint z).
+  Proof using Hmod.
+    intros Hrepr Hto Hty. rewrite /conv_float Hrepr /=. split; first apply has_float_type.
+    by rewrite Hto.
+  Qed.
+
+  Lemma conv_float_widen (fv : float_type.car float_type.Ffloat) fv' :
+      float_value.cast float_type.Ffloat float_type.Fdouble fv = Some fv' ->
+      conv_float tu Tfloat Tdouble (Vfloat float_type.Ffloat fv) (Vfloat float_type.Fdouble fv').
+  Proof using Hmod. apply conv_float_cast. Qed.
+
+  Lemma conv_float_narrow (fv : float_type.car float_type.Fdouble) fv' :
+      float_value.cast float_type.Fdouble float_type.Ffloat fv = Some fv' ->
+      conv_float tu Tdouble Tfloat (Vfloat float_type.Fdouble fv) (Vfloat float_type.Ffloat fv').
+  Proof using Hmod. apply conv_float_cast. Qed.
 End conv_float.
 
 (* This (effectively) lifts [conv_int] to arbitrary types.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/cast.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/cast.v
@@ -256,7 +256,7 @@ Definition conv_float {σ : genv} (tu : translation_unit) (from to : type) (v v'
       end
   | Tfloat_ _ , Tbool =>
       match v with
-      | Vfloat f z => v' = Vbool (float_value.is_true f z)
+      | Vfloat f z => v' = Vbool (float_value.is_true z)
       | _ => False
       end
   | Tfloat_ _ , Tnum _ _ =>
@@ -353,7 +353,7 @@ Section conv_float.
 
   Lemma conv_float_to_bool ft (fv : float_type.car ft) :
       conv_float tu (Tfloat_ ft) Tbool (Vfloat ft fv)
-        (Vbool (float_value.is_true ft fv)).
+        (Vbool (float_value.is_true fv)).
   Proof using Hmod.
     rewrite /conv_float /=. split; first apply has_float_type. done.
   Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/cast_operator.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/cast_operator.v
@@ -43,26 +43,30 @@ Definition float_rank (ft : float_type.t) : nat :=
 Definition max_float_type (ft1 ft2 : float_type.t) : float_type.t :=
   if Nat.leb (float_rank ft1) (float_rank ft2) then ft2 else ft1.
 
-Definition usual_float_arith (tu : translation_unit) (ty1 ty2 : type) : option type :=
+(** The floating point type used to perform arithmetic operations between the two C++ types *)
+Definition usual_float_arith (tu : translation_unit) (ty1 ty2 : type) : option float_type.t :=
   match supported_float_type ty1, supported_float_type ty2 with
-  | Some ft1, Some ft2 => Some (Tfloat_ (max_float_type ft1 ft2))
+  | Some ft1, Some ft2 => Some $ max_float_type ft1 ft2
   | Some ft, None =>
       match promote_integral tu ty2 with
-      | Some _ => Some (Tfloat_ ft)
+      | Some _ => Some ft
       | None => None
       end
   | None, Some ft =>
       match promote_integral tu ty1 with
-      | Some _ => Some (Tfloat_ ft)
+      | Some _ => Some ft
       | None => None
       end
   | None, None => None
   end.
 
-Definition convert_type_float_op (b : BinOp) (to : type) : option (type * type * type) :=
+(** The effective type of <<operator b(to, to) -> ?>>.
+    This is mainly handling installing the return type.
+ *)
+Definition result_type (b : BinOp) (to : type) : option type :=
   match b with
-  | Badd | Bsub | Bmul | Bdiv => Some (to, to, to)
-  | Beq | Bneq | Blt | Ble | Bgt | Bge => Some (to, to, Tbool)
+  | Badd | Bsub | Bmul | Bdiv => Some to
+  | Beq | Bneq | Blt | Ble | Bgt | Bge => Some Tbool
   | Bmod | Band | Bor | Bxor | Bshl | Bshr | Bcmp
   | Bdotp | Bdotip | Bunsupported _ => None
   end.
@@ -105,7 +109,7 @@ Definition convert_type_op (tu : translation_unit) (b : BinOp) (ty1 ty2 : type)
     end
   else if is_arithmetic ty1 && is_arithmetic ty2 then
     match usual_float_arith tu ty1 ty2 with
-    | Some to => convert_type_float_op b to
+    | Some to => (fun res : type => (Tfloat_ to, Tfloat_ to, res)) <$> result_type b (Tfloat_ to)
     | None =>
       (* integer-integer operations *)
       match promote_integral tu ty1 , promote_integral tu ty2 with

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/cast_operator.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/cast_operator.v
@@ -25,6 +25,48 @@ Require Import skylabs.lang.cpp.semantics.cast.
   *)
 Notation Tptrdiff_t := Tlonglong (only parsing).
 
+Definition supported_float_type (ty : type) : option float_type.t :=
+  match drop_qualifiers ty with
+  | Tfloat_ ft => if float_type.supported ft then Some ft else None
+  | _ => None
+  end.
+
+Definition float_rank (ft : float_type.t) : nat :=
+  match ft with
+  | float_type.Ffloat16 => 0%nat
+  | float_type.Ffloat => 1%nat
+  | float_type.Fdouble => 2%nat
+  | float_type.Flongdouble => 3%nat
+  | float_type.Ffloat128 => 4%nat
+  end.
+
+Definition max_float_type (ft1 ft2 : float_type.t) : float_type.t :=
+  if Nat.leb (float_rank ft1) (float_rank ft2) then ft2 else ft1.
+
+Definition usual_float_arith (tu : translation_unit) (ty1 ty2 : type) : option type :=
+  match supported_float_type ty1, supported_float_type ty2 with
+  | Some ft1, Some ft2 => Some (Tfloat_ (max_float_type ft1 ft2))
+  | Some ft, None =>
+      match promote_integral tu ty2 with
+      | Some _ => Some (Tfloat_ ft)
+      | None => None
+      end
+  | None, Some ft =>
+      match promote_integral tu ty1 with
+      | Some _ => Some (Tfloat_ ft)
+      | None => None
+      end
+  | None, None => None
+  end.
+
+Definition convert_type_float_op (b : BinOp) (to : type) : option (type * type * type) :=
+  match b with
+  | Badd | Bsub | Bmul | Bdiv => Some (to, to, to)
+  | Beq | Bneq | Blt | Ble | Bgt | Bge => Some (to, to, Tbool)
+  | Bmod | Band | Bor | Bxor | Bshl | Bshr | Bcmp
+  | Bdotp | Bdotip | Bunsupported _ => None
+  end.
+
 (** For a binary operation between two types, determine the type of the result and the necessary conversions on the operands.
 
 This is used for both pointer and arithmetic operators.
@@ -62,45 +104,49 @@ Definition convert_type_op (tu : translation_unit) (b : BinOp) (ty1 ty2 : type)
     | _ => None
     end
   else if is_arithmetic ty1 && is_arithmetic ty2 then
-    (* integer-integer operations *)
-    match promote_integral tu ty1 , promote_integral tu ty2 with
-    | Some ity1 , Some ity2 =>
-      match b with
-      | Bshl | Bshr =>
-        (* heterogeneous operators *)
-        Some (ity1, ity2, ity1)
-      | Badd | Bsub | Bmul | Bdiv | Bmod
-      | Band | Bor | Bxor =>
-        (* homogeneous operators *)
-        match promote_arith ity1 ity2 with
-        | Some to => Some (to, to, to)
-        | _ => None
-        end
-      | Beq | Bneq
-      | Blt | Ble | Bgt | Bge =>
-        let same_enum :=
-          match drop_qualifiers ty1 , drop_qualifiers ty2 with
-          | Tenum nm1 , Tenum nm2 => if bool_decide (nm1 = nm2) then true else false
-          | _ , _ => false
-          end
-        in
-        if same_enum then
-          (* Technically, this is only permitted for unscoped enumerations;
-             however, the dynamic semantics lines up with the comparison on
-             scoped enumerations so we do not test.
-           *)
-          Some (drop_qualifiers ty1, drop_qualifiers ty2, Tbool)
-        else
+    match usual_float_arith tu ty1 ty2 with
+    | Some to => convert_type_float_op b to
+    | None =>
+      (* integer-integer operations *)
+      match promote_integral tu ty1 , promote_integral tu ty2 with
+      | Some ity1 , Some ity2 =>
+        match b with
+        | Bshl | Bshr =>
+          (* heterogeneous operators *)
+          Some (ity1, ity2, ity1)
+        | Badd | Bsub | Bmul | Bdiv | Bmod
+        | Band | Bor | Bxor =>
           (* homogeneous operators *)
           match promote_arith ity1 ity2 with
           | Some to => Some (to, to, to)
           | _ => None
           end
-      | Bcmp => None
-      | Bdotp
-      | Bdotip
-      | Bunsupported _ => None
+        | Beq | Bneq
+        | Blt | Ble | Bgt | Bge =>
+          let same_enum :=
+            match drop_qualifiers ty1 , drop_qualifiers ty2 with
+            | Tenum nm1 , Tenum nm2 => if bool_decide (nm1 = nm2) then true else false
+            | _ , _ => false
+            end
+          in
+          if same_enum then
+            (* Technically, this is only permitted for unscoped enumerations;
+               however, the dynamic semantics lines up with the comparison on
+               scoped enumerations so we do not test.
+             *)
+            Some (drop_qualifiers ty1, drop_qualifiers ty2, Tbool)
+          else
+            (* homogeneous operators *)
+            match promote_arith ity1 ity2 with
+            | Some to => Some (to, to, to)
+            | _ => None
+            end
+        | Bcmp => None
+        | Bdotp
+        | Bdotip
+        | Bunsupported _ => None
+        end
+      | _ , _ => None
       end
-    | _ , _ => None
     end
   else None.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/characters.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/characters.v
@@ -47,6 +47,34 @@ Definition of_char (from_bits : N) (from_sgn : signed) (to_bits : N) (to_sgn : s
     else n in
   if to_sgn is Signed then to_signed_bits to_bits n else to_unsigned_bits to_bits n.
 
+Definition char_to_Z_for_float (σ : genv) (ct : char_type.t) (n : N) : Z :=
+  of_char (char_type.bitsN ct) (signedness_of_char σ ct)
+    (int_rank.bitsN int_rank.I128) Signed n.
+
+Definition char_float_bound (σ : genv) (ct : char_type.t) (z : Z) : Prop :=
+  let bits := char_type.bitsN ct in
+  match signedness_of_char σ ct with
+  | Signed => (- 2 ^ (bits - 1) <= z < 2 ^ (bits - 1))%Z
+  | Unsigned => (0 <= z < 2 ^ bits)%Z
+  end.
+
+Definition char_float_boundb (σ : genv) (ct : char_type.t) (z : Z) : bool :=
+  let bits := char_type.bitsN ct in
+  match signedness_of_char σ ct with
+  | Signed => ((- 2 ^ (bits - 1) <=? z) && (z <? 2 ^ (bits - 1)))%Z
+  | Unsigned => ((0 <=? z) && (z <? 2 ^ bits))%Z
+  end.
+
+Definition Z_to_char_bits (ct : char_type.t) (z : Z) : N :=
+  Z.to_N (z `mod` 2 ^ char_type.bitsN ct).
+
+Definition float_to_char (σ : genv) (ft : float_type.t) (ct : char_type.t)
+    (f : float_type.car ft) : option N :=
+  match float_value.to_int ft f with
+  | Some z => if char_float_boundb σ ct z then Some (Z_to_char_bits ct z) else None
+  | None => None
+  end.
+
 (* suppose that you are in an architecture with unsigned characters
     and you wrote (128)
   *)
@@ -365,6 +393,26 @@ Proof.
   generalize (Z_mod_lt z (2^bits)). lia.
 Qed.
 
+Lemma char_float_boundb_spec {σ : genv} ct z :
+  char_float_boundb σ ct z = true <-> char_float_bound σ ct z.
+Proof.
+  rewrite /char_float_boundb /char_float_bound.
+  destruct (signedness_of_char σ ct); rewrite andb_true_iff Z.leb_le Z.ltb_lt; tauto.
+Qed.
+
+Lemma Z_to_char_bits_bounded ct z :
+  (0 <= Z_to_char_bits ct z < 2 ^ char_type.bitsN ct)%N.
+Proof.
+  split; first apply N.le_0_l.
+  rewrite /Z_to_char_bits.
+  apply N2Z.inj_lt.
+  rewrite Z2N.id.
+  - replace (Z.of_N (2 ^ char_type.bitsN ct)%N) with (2 ^ char_type.bitsN ct)%Z
+      by (destruct ct; reflexivity).
+    apply Z_mod_lt. destruct ct; simpl; lia.
+  - apply Z_mod_lt. destruct ct; simpl; lia.
+Qed.
+
 Lemma of_char_bounded (from_sz : N) from_sgn (to_sz : N) to_sgn n :
   0 < to_sz -> 0< from_sz ->
   let min_val : Z := if to_sgn is Signed then -2^(to_sz-1) else 0 in
@@ -384,4 +432,26 @@ Proof.
           end
       end.
   repeat first [ case_bool_decide | case_match ]; rewrite /trim/=; split; try rewrite Zmod_0_l ; saturate; try lia.
+Qed.
+
+Lemma char_to_Z_for_float_bounded {σ : genv} ct n :
+  has_type_prop (Vchar n) (Tchar_ ct) ->
+  bitsize.bound (int_rank.bitsize int_rank.I128) Signed (char_to_Z_for_float σ ct n).
+Proof.
+  intros _.
+  rewrite /char_to_Z_for_float /bitsize.bound /bitsize.min_val /bitsize.max_val.
+  pose proof (of_char_bounded (char_type.bitsN ct) (signedness_of_char σ ct)
+                (int_rank.bitsN int_rank.I128) Signed n) as H.
+  destruct ct; simpl in *; specialize (H ltac:(lia) ltac:(lia)); lia.
+Qed.
+
+Lemma float_to_char_has_type {σ : genv} ft ct (f : float_type.car ft) n :
+  float_to_char σ ft ct f = Some n ->
+  has_type_prop (Vchar n) (Tchar_ ct).
+Proof.
+  rewrite /float_to_char.
+  destruct (float_value.to_int ft f) as [z|] eqn:HtoZ; try discriminate.
+  destruct (char_float_boundb σ ct z) eqn:Hbound; inversion 1; subst.
+  apply has_type_prop_char'.
+  apply Z_to_char_bits_bounded.
 Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
@@ -110,7 +110,7 @@ Axiom eval_not_bool : forall a,
 
 Axiom eval_not_float : forall ft (a : float_type.car ft),
     eval_unop Unot (Tfloat_ ft) Tbool
-      (Vfloat ft a) (Vbool (negb (float_value.is_true ft a))).
+      (Vfloat ft a) (Vbool (negb (float_value.is_true a))).
 
 (* The builtin unary `~` operator computes the bitwise negation of the operator
    https://eel.is/c++draft/expr.unary.op#10

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
@@ -108,6 +108,10 @@ Section operator_axioms.
 Axiom eval_not_bool : forall a,
     eval_unop Unot Tbool Tbool (Vbool a) (Vbool (negb a)).
 
+Axiom eval_not_float : forall ft (a : float_type.car ft),
+    eval_unop Unot (Tfloat_ ft) Tbool
+      (Vfloat ft a) (Vbool (negb (float_value.is_true ft a))).
+
 (* The builtin unary `~` operator computes the bitwise negation of the operator
    https://eel.is/c++draft/expr.unary.op#10
 

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
@@ -144,7 +144,7 @@ Module Type VAL_MIXIN (Import P : PTRS) (Import R : RAW_BYTES).
   Definition is_true (v : val) : option bool :=
     match v with
     | Vint v => Some (bool_decide (v <> 0))
-    | Vfloat f v => Some (float_value.is_true f v)
+    | Vfloat f v => Some (float_value.is_true v)
     | Vptr p => Some (bool_decide (p <> nullptr))
     | Vchar n => Some (bool_decide (n <> 0%N))
     | Vundef | Vraw _ => None

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
@@ -257,10 +257,8 @@ Module Type RAW_BYTES_VAL
       raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs <->
       rs = float_raw_bytes σ ft f.
 
-  Axiom raw_bytes_of_val_float_unique_val : forall {σ ft} (f f' : float_type.car ft) rs,
-      raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs ->
-      raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f') rs ->
-      f = f'.
+  #[global] Declare Instance float_raw_bytes_inj : forall {σ ft},
+      Inj (=) (=) (float_raw_bytes σ ft).
 
   (* TODO Maybe add?
     Axiom raw_bytes_of_val_int : forall σ sz z rs,

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
@@ -15,6 +15,7 @@ Require Import skylabs.prelude.numbers.
 Require Import skylabs.lang.cpp.reserved_notation. (* TODO *)
 Require Import skylabs.prelude.arith.operator.
 Require Import skylabs.prelude.arith.builtins.
+Require Import skylabs.prelude.arith.z_to_bytes.
 Require Import skylabs.lang.cpp.syntax.
 Require Export skylabs.lang.cpp.semantics.types.
 Require Export skylabs.lang.cpp.semantics.sub_module.
@@ -143,7 +144,7 @@ Module Type VAL_MIXIN (Import P : PTRS) (Import R : RAW_BYTES).
   Definition is_true (v : val) : option bool :=
     match v with
     | Vint v => Some (bool_decide (v <> 0))
-    | Vfloat f v => Some (bool_decide (v <> float_value.zero _))
+    | Vfloat f v => Some (float_value.is_true f v)
     | Vptr p => Some (bool_decide (p <> nullptr))
     | Vchar n => Some (bool_decide (n <> 0%N))
     | Vundef | Vraw _ => None
@@ -240,6 +241,26 @@ Module Type RAW_BYTES_VAL
 
   Axiom raw_bytes_of_val_sizeof : forall {σ ty v rs},
       raw_bytes_of_val σ ty v rs -> size_of σ ty = Some (N.of_nat $ length rs).
+
+  Definition float_raw_bytes (σ : genv) ft (f : float_type.car ft) : list raw_byte :=
+    raw_int_byte <$> _Z_to_bytes (N.to_nat (float_type.bytesN ft))
+      (genv_byte_order σ) Unsigned (float_value.to_bits ft f).
+
+  Lemma float_raw_bytes_length σ ft (f : float_type.car ft) :
+    length (float_raw_bytes σ ft f) = N.to_nat (float_type.bytesN ft).
+  Proof. by rewrite /float_raw_bytes length_fmap _Z_to_bytes_length. Qed.
+
+  (** Float raw-byte support is intentionally narrow: the byte sequence is the
+      deterministic object-size encoding of [float_value.to_bits].  Equality of
+      such encodings for values of the same float type determines the value. *)
+  Axiom raw_bytes_of_val_float : forall {σ ft} (f : float_type.car ft) rs,
+      raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs <->
+      rs = float_raw_bytes σ ft f.
+
+  Axiom raw_bytes_of_val_float_unique_val : forall {σ ft} (f f' : float_type.car ft) rs,
+      raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs ->
+      raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f') rs ->
+      f = f'.
 
   (* TODO Maybe add?
     Axiom raw_bytes_of_val_int : forall σ sz z rs,
@@ -464,6 +485,23 @@ Module Type RAW_BYTES_MIXIN
   Proof.
     move => /raw_bytes_of_val_sizeof/=.
     rewrite /int_rank.bytesN /bitsize.bytesN.
+    inversion 1. lia.
+  Qed.
+
+  Lemma raw_bytes_of_val_float_length {σ} ft (f : float_type.car ft) rs :
+    raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs ->
+    length rs = N.to_nat (float_type.bytesN ft).
+  Proof.
+    move=> Hraw.
+    apply raw_bytes_of_val_float in Hraw. subst.
+    apply float_raw_bytes_length.
+  Qed.
+
+  Lemma raw_bytes_of_val_float_undef_length {σ} ft rs :
+    raw_bytes_of_val σ (Tfloat_ ft) Vundef rs ->
+    length rs = N.to_nat (float_type.bytesN ft).
+  Proof.
+    move => /raw_bytes_of_val_sizeof/=.
     inversion 1. lia.
   Qed.
 End RAW_BYTES_MIXIN.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -500,17 +500,6 @@ Module float_type.
     t <> Flongdouble -> bit_width t = bitsize.bitsZ (bitsize t).
   Proof. by destruct t. Qed.
 
-  Lemma bit_width_Ffloat16 : bit_width Ffloat16 = 16%Z.
-  Proof. reflexivity. Qed.
-  Lemma bit_width_Ffloat : bit_width Ffloat = 32%Z.
-  Proof. reflexivity. Qed.
-  Lemma bit_width_Fdouble : bit_width Fdouble = 64%Z.
-  Proof. reflexivity. Qed.
-  Lemma bit_width_Flongdouble : bit_width Flongdouble = 79%Z.
-  Proof. reflexivity. Qed.
-  Lemma bit_width_Ffloat128 : bit_width Ffloat128 = 128%Z.
-  Proof. reflexivity. Qed.
-
   (** The carrier type *)
   Definition car (t : t) : Set :=
     binary_float (mw t) (ew t).
@@ -567,13 +556,13 @@ Module float_value.
     | _ => false
     end.
 
-  Definition is_true (t : t) (v : car t) : bool :=
+  Definition is_true {t : t} (v : car t) : bool :=
     negb (is_zero v).
 
   Lemma is_zero_zero (t : t) : is_zero (zero t) = true.
   Proof. by destruct t. Qed.
 
-  Lemma is_true_zero (t : t) : is_true t (zero t) = false.
+  Lemma is_true_zero (t : t) : is_true (zero t) = false.
   Proof. by destruct t. Qed.
 
   Definition default_nan (t : t) : { nan : car t | is_nan _ _ nan = true } :=
@@ -773,23 +762,7 @@ Module float_value.
     (0 <= z < 2 ^ 128)%Z -> to_bits Ffloat128 (of_bits Ffloat128 z) = z.
   Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
 
-  Lemma of_to_bits_Ffloat16 (f : car Ffloat16) :
-    of_bits Ffloat16 (to_bits Ffloat16 f) = f.
-  Proof. apply of_to_bits. Qed.
-
-  Lemma of_to_bits_Ffloat (f : car Ffloat) :
-    of_bits Ffloat (to_bits Ffloat f) = f.
-  Proof. apply of_to_bits. Qed.
-
-  Lemma of_to_bits_Fdouble (f : car Fdouble) :
-    of_bits Fdouble (to_bits Fdouble f) = f.
-  Proof. apply of_to_bits. Qed.
-
-  Lemma of_to_bits_Ffloat128 (f : car Ffloat128) :
-    of_bits Ffloat128 (to_bits Ffloat128 f) = f.
-  Proof. apply of_to_bits. Qed.
-
-  Lemma to_bits_inj ft : Inj (=) (=) (to_bits ft).
+  #[global] Instance to_bits_inj ft : Inj (=) (=) (to_bits ft).
   Proof.
     intros x y Hbits.
     apply (f_equal (of_bits ft)) in Hbits.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -422,6 +422,28 @@ Module float_type.
   Definition bitsN (t : t) : N :=
     8 * bytesN t.
 
+  (** Additive support predicate for frontend/checker compatibility. *)
+  Definition supported (_ : t) : bool := true.
+
+  (** Object-representation size when it is one of BRiCk's fixed integer
+      bit-widths.  For [Flongdouble], this is the 16-byte object size; its
+      Flocq bit encoding below has a smaller [bit_width]. *)
+  Definition bitsize (t : t) : bitsize.t :=
+    match t with
+    | Ffloat16 => bitsize.W16
+    | Ffloat => bitsize.W32
+    | Fdouble => bitsize.W64
+    | Flongdouble | Ffloat128 => bitsize.W128
+    end.
+
+  Lemma bitsize_bytesN (t : t) :
+    bitsize.bytesN (bitsize t) = bytesN t.
+  Proof. by destruct t. Qed.
+
+  Lemma bitsize_bitsN (t : t) :
+    bitsize.bitsN (bitsize t) = bitsN t.
+  Proof. by destruct t. Qed.
+
   (** Parameters for [binary_float].
 
       [mw] is the significand precision, including the implicit leading bit
@@ -465,6 +487,29 @@ Module float_type.
    *)
   Definition fraction_bits (t : t) : Z := mw t - 1.
   Definition exponent_bits (t : t) : Z := Z.log2 (ew t) + 1.
+  Definition bit_width (t : t) : Z := 1 + fraction_bits t + exponent_bits t.
+
+  Lemma bit_width_nonnegative (t : t) : (0 <= bit_width t)%Z.
+  Proof. by destruct t. Qed.
+
+  Lemma bit_width_le_bitsN (t : t) :
+    (bit_width t <= Z.of_N (bitsN t))%Z.
+  Proof. by destruct t. Qed.
+
+  Lemma bit_width_bitsize_not_longdouble (t : t) :
+    t <> Flongdouble -> bit_width t = bitsize.bitsZ (bitsize t).
+  Proof. by destruct t. Qed.
+
+  Lemma bit_width_Ffloat16 : bit_width Ffloat16 = 16%Z.
+  Proof. reflexivity. Qed.
+  Lemma bit_width_Ffloat : bit_width Ffloat = 32%Z.
+  Proof. reflexivity. Qed.
+  Lemma bit_width_Fdouble : bit_width Fdouble = 64%Z.
+  Proof. reflexivity. Qed.
+  Lemma bit_width_Flongdouble : bit_width Flongdouble = 79%Z.
+  Proof. reflexivity. Qed.
+  Lemma bit_width_Ffloat128 : bit_width Ffloat128 = 128%Z.
+  Proof. reflexivity. Qed.
 
   (** The carrier type *)
   Definition car (t : t) : Set :=
@@ -521,6 +566,15 @@ Module float_value.
     | B754_zero _ _ _ => true
     | _ => false
     end.
+
+  Definition is_true (t : t) (v : car t) : bool :=
+    negb (is_zero v).
+
+  Lemma is_zero_zero (t : t) : is_zero (zero t) = true.
+  Proof. by destruct t. Qed.
+
+  Lemma is_true_zero (t : t) : is_true t (zero t) = false.
+  Proof. by destruct t. Qed.
 
   Definition default_nan (t : t) : { nan : car t | is_nan _ _ nan = true } :=
     match t return { nan : car t | is_nan _ _ nan = true } with
@@ -669,6 +723,78 @@ Module float_value.
 
   Definition geb (t : t) (v1 v2 : car t) : bool :=
     leb t v2 v1.
+
+  Lemma of_to_bits ft (f : car ft) : of_bits ft (to_bits ft f) = f.
+  Proof.
+    destruct ft; simpl in *.
+    - exact (binary_float_of_bits_of_binary_float 10 5 (refl_equal _) (refl_equal _) (refl_equal _) f).
+    - exact (binary_float_of_bits_of_binary_float 23 8 (refl_equal _) (refl_equal _) (refl_equal _) f).
+    - exact (binary_float_of_bits_of_binary_float 52 11 (refl_equal _) (refl_equal _) (refl_equal _) f).
+    - exact (binary_float_of_bits_of_binary_float 63 15 (refl_equal _) (refl_equal _) (refl_equal _) f).
+    - exact (binary_float_of_bits_of_binary_float 112 15 (refl_equal _) (refl_equal _) (refl_equal _) f).
+  Qed.
+
+  Lemma to_bits_range ft (f : car ft) :
+    (0 <= to_bits ft f < 2 ^ float_type.bit_width ft)%Z.
+  Proof.
+    destruct ft; simpl in *.
+    - exact (bits_of_binary_float_range 10 5 ltac:(lia) ltac:(lia) f).
+    - exact (bits_of_binary_float_range 23 8 ltac:(lia) ltac:(lia) f).
+    - exact (bits_of_binary_float_range 52 11 ltac:(lia) ltac:(lia) f).
+    - exact (bits_of_binary_float_range 63 15 ltac:(lia) ltac:(lia) f).
+    - exact (bits_of_binary_float_range 112 15 ltac:(lia) ltac:(lia) f).
+  Qed.
+
+  Lemma to_of_bits ft z :
+    (0 <= z < 2 ^ float_type.bit_width ft)%Z ->
+    to_bits ft (of_bits ft z) = z.
+  Proof.
+    destruct ft; simpl; intros Hz.
+    - exact (bits_of_binary_float_of_bits 10 5 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
+    - exact (bits_of_binary_float_of_bits 23 8 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
+    - exact (bits_of_binary_float_of_bits 52 11 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
+    - exact (bits_of_binary_float_of_bits 63 15 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
+    - exact (bits_of_binary_float_of_bits 112 15 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
+  Qed.
+
+  Lemma to_of_bits_Ffloat16 z :
+    (0 <= z < 2 ^ 16)%Z -> to_bits Ffloat16 (of_bits Ffloat16 z) = z.
+  Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
+
+  Lemma to_of_bits_Ffloat z :
+    (0 <= z < 2 ^ 32)%Z -> to_bits Ffloat (of_bits Ffloat z) = z.
+  Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
+
+  Lemma to_of_bits_Fdouble z :
+    (0 <= z < 2 ^ 64)%Z -> to_bits Fdouble (of_bits Fdouble z) = z.
+  Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
+
+  Lemma to_of_bits_Ffloat128 z :
+    (0 <= z < 2 ^ 128)%Z -> to_bits Ffloat128 (of_bits Ffloat128 z) = z.
+  Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
+
+  Lemma of_to_bits_Ffloat16 (f : car Ffloat16) :
+    of_bits Ffloat16 (to_bits Ffloat16 f) = f.
+  Proof. apply of_to_bits. Qed.
+
+  Lemma of_to_bits_Ffloat (f : car Ffloat) :
+    of_bits Ffloat (to_bits Ffloat f) = f.
+  Proof. apply of_to_bits. Qed.
+
+  Lemma of_to_bits_Fdouble (f : car Fdouble) :
+    of_bits Fdouble (to_bits Fdouble f) = f.
+  Proof. apply of_to_bits. Qed.
+
+  Lemma of_to_bits_Ffloat128 (f : car Ffloat128) :
+    of_bits Ffloat128 (to_bits Ffloat128 f) = f.
+  Proof. apply of_to_bits. Qed.
+
+  Lemma to_bits_inj ft : Inj (=) (=) (to_bits ft).
+  Proof.
+    intros x y Hbits.
+    apply (f_equal (of_bits ft)) in Hbits.
+    by rewrite !of_to_bits in Hbits.
+  Qed.
 
 End float_value.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -422,8 +422,12 @@ Module float_type.
   Definition bitsN (t : t) : N :=
     8 * bytesN t.
 
-  (** Additive support predicate for frontend/checker compatibility. *)
-  Definition supported (_ : t) : bool := true.
+  (** Frontend/checker support predicate. *)
+  Definition supported (t : t) : bool :=
+    match t with
+    | Flongdouble => false
+    | _ => true
+    end.
 
   (** Object-representation size when it is one of BRiCk's fixed integer
       bit-widths.  For [Flongdouble], this is the 16-byte object size; its

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -6,6 +6,8 @@
 
 Require Import skylabs.prelude.base.
 Require Import skylabs.lang.cpp.syntax.core.
+Require Import skylabs.lang.cpp.syntax.types.
+Require Import skylabs.lang.cpp.syntax.typing.
 Require Import skylabs.lang.cpp.syntax.translation_unit.
 Require Import skylabs.lang.cpp.syntax.templates.
 
@@ -20,6 +22,85 @@ Section with_monad.
   #[local] Infix "<+>" := op (at level 30).
   #[local] Notation opt f := (from_option f OK).
   #[local] Notation lst f xs := (List.concat (List.map f xs)).
+
+  Definition check_float_width (ft : float_type.t) : M :=
+    if float_type.supported ft then OK else FAIL "unsupported floating width".
+
+  Definition as_float_type (t : type) : option float_type.t :=
+    match drop_qualifiers t with
+    | Tfloat_ ft => Some ft
+    | _ => None
+    end.
+
+  Definition is_float_type (t : type) : bool :=
+    if as_float_type t is Some _ then true else false.
+
+  Definition check_float_type_if_present (t : type) : M :=
+    match as_float_type t with
+    | Some ft => check_float_width ft
+    | None => OK
+    end.
+
+  Definition check_float_cast_target (t : type) : M :=
+    match as_float_type t with
+    | Some ft => check_float_width ft
+    | None => FAIL "expected floating cast target"
+    end.
+
+  Definition check_float_cast_source (t : type) : M :=
+    match as_float_type t with
+    | Some ft => check_float_width ft
+    | None => FAIL "expected floating cast source"
+    end.
+
+  Definition check_unop (op : UnOp) (argT resT : type) : M :=
+    (match op with
+     | Uunsupported msg => FAIL msg
+     | _ => OK
+     end) <+>
+    if is_float_type argT || is_float_type resT then
+      check_float_type_if_present argT <+> check_float_type_if_present resT <+>
+      match op with
+      | Uplus | Uminus | Unot => OK
+      | Ubnot => FAIL "unsupported floating unary operator"
+      | Uunsupported _ => OK
+      end
+    else OK.
+
+  Definition check_binop (op : BinOp) (lhsT rhsT resT : type) : M :=
+    (match op with
+     | Bunsupported msg => FAIL msg
+     | _ => OK
+     end) <+>
+    if is_float_type lhsT || is_float_type rhsT || is_float_type resT then
+      check_float_type_if_present lhsT <+>
+      check_float_type_if_present rhsT <+>
+      check_float_type_if_present resT <+>
+      if is_pointer lhsT || is_pointer rhsT then
+        FAIL "unsupported pointer/floating operator"
+      else
+        match op with
+        | Badd | Bsub | Bmul | Bdiv
+        | Beq | Bneq | Blt | Ble | Bgt | Bge => OK
+        | Bmod | Band | Bor | Bxor | Bshl | Bshr | Bcmp
+        | Bdotp | Bdotip => FAIL "unsupported floating binary operator"
+        | Bunsupported _ => OK
+        end
+    else OK.
+
+  Definition check_float_cast_expr (c : Cast) (srcT : type) : M :=
+    match c with
+    | Cfloat t =>
+        check_float_cast_source srcT <+> check_float_cast_target t
+    | Cint2float t =>
+        check_float_cast_target t <+>
+        if is_float_type srcT then FAIL "invalid floating cast source" else OK
+    | Cfloat2int t =>
+        check_float_cast_source srcT <+>
+        if is_float_type t then FAIL "invalid floating cast target" else OK
+    | Cfloat2bool => check_float_cast_source srcT
+    | _ => OK
+    end.
 
   Definition atomic_name (type : type -> M) (an : atomic_name) : M :=
     match an with
@@ -83,7 +164,8 @@ Section with_monad.
     | Tresult_member t _ => type t
     | Tauto => OK
     | Tptr t | Tref t | Trv_ref t | Tarray t _ | Tincomplete_array t => type t
-    | Tnum _ _ | Tchar_ _ | Tvoid | Tbool | Tfloat_ _ | Tnullptr => OK
+    | Tnum _ _ | Tchar_ _ | Tvoid | Tbool | Tnullptr => OK
+    | Tfloat_ ft => check_float_width ft
     | Tvariable_array t e => type t <+> expr e
     | Tfunction (FunctionType t ts) => type t <+> lst type ts
     | Tmember_pointer t1 t2 => type t1 <+> type t2
@@ -99,10 +181,10 @@ Section with_monad.
     | Eenum_const n _ => name n
     | Eglobal n t | Eglobal_member n t => name n <+> type t
     | Echar _ t | Estring _ t | Eunresolved_string_literal t | Eint _ t => type t
-    | Efloat _ _
+    | Efloat ft _ => check_float_width ft
     | Ebool _ => OK
-    | Eunop _ e t => expr e <+> type t
-    | Ebinop _ e1 e2 t => expr e1 <+> type t
+    | Eunop op e t => expr e <+> type t <+> check_unop op (type_of e) t
+    | Ebinop op e1 e2 t => expr e1 <+> expr e2 <+> type t <+> check_binop op (type_of e1) (type_of e2) t
     | Ederef e t => expr e <+> type t
     | Eaddrof e => expr e
     | Esubscript e1 e2 t => expr e1 <+> expr e2 <+> type t
@@ -113,8 +195,11 @@ Section with_monad.
         | inl t => type t
         end <+> type t
     | Eoffsetof t1 _ t2 => type t1 <+> type t2
-    | Eassign e1 e2 t | Eassign_op _ e1 e2 t => expr e1 <+> expr e2 <+> type t
-    | Epreinc e t | Epostinc e t | Epredec e t | Epostdec e t => expr e <+> type t
+    | Eassign e1 e2 t => expr e1 <+> expr e2 <+> type t
+    | Eassign_op op e1 e2 t => expr e1 <+> expr e2 <+> type t <+> check_binop op (type_of e1) (type_of e2) t
+    | Epreinc e t | Epostinc e t | Epredec e t | Epostdec e t =>
+        expr e <+> type t <+>
+        if is_float_type (type_of e) || is_float_type t then FAIL "unsupported floating increment/decrement" else OK
     | Eseqand e1 e2 | Eseqor e1 e2 | Ecomma e1 e2 => expr e1 <+> expr e2
     | Ecall e es => expr e <+> lst expr es
     | Eoperator_call _ _ es => lst expr es
@@ -130,7 +215,7 @@ Section with_monad.
         name n <+> type t <+> lst expr es <+> type t1 <+> opt expr oe1 <+> opt expr oe2
     | Edelete _ n e t => name n <+> expr e <+> type t
     | Eexplicit_cast _ t e => type t <+> expr e
-    | Ecast c e => cast c <+> expr e
+    | Ecast c e => cast c <+> expr e <+> check_float_cast_expr c (type_of e)
     | Emember _ e an _ t => expr e <+> atomic_name type an <+> type t
     | Estmt s t => stmt s <+> type t
     | Enull => OK
@@ -205,7 +290,9 @@ Section with_monad.
     | Cnull2ptr t | Cnull2memberptr t
     | Cbuiltin2fun t | Cctor t | Cdynamic t => type t
     | Cderived2base ts t | Cbase2derived ts t => lst type ts <+> type t
-    | Cfloat _ | Cint2float _ | Cfloat2int _ | Cfloat2bool => FAIL "float"
+    | Cfloat t | Cint2float t => check_float_cast_target t
+    | Cfloat2int t => type t <+> if is_float_type t then FAIL "invalid floating cast target" else OK
+    | Cfloat2bool => OK
     | Cl2r_bitcast _ => FAIL "l2r_bitcast"
     | _ => OK
     end.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -12,6 +12,14 @@ Require Import skylabs.lang.cpp.syntax.translation_unit.
 Require Import skylabs.lang.cpp.syntax.templates.
 Require Import skylabs.lang.cpp.semantics.cast_operator.
 
+(** ** Supported Check
+
+    This file implements a *light-weight* check on terms to determine if they
+    contain unsupported features. A deeper check can be performed using type
+    checking, see [typed.v](typed.v).
+
+ *)
+
 Module check.
 Section with_monad.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -10,6 +10,7 @@ Require Import skylabs.lang.cpp.syntax.types.
 Require Import skylabs.lang.cpp.syntax.typing.
 Require Import skylabs.lang.cpp.syntax.translation_unit.
 Require Import skylabs.lang.cpp.syntax.templates.
+Require Import skylabs.lang.cpp.semantics.cast_operator.
 
 Module check.
 Section with_monad.
@@ -67,6 +68,12 @@ Section with_monad.
       end
     else OK.
 
+  Definition check_float_binop (op : BinOp) : M :=
+    match convert_type_float_op op Tfloat with
+    | Some _ => OK
+    | None => FAIL "unsupported floating binary operator"
+    end.
+
   Definition check_binop (op : BinOp) (lhsT rhsT resT : type) : M :=
     (match op with
      | Bunsupported msg => FAIL msg
@@ -80,11 +87,8 @@ Section with_monad.
         FAIL "unsupported pointer/floating operator"
       else
         match op with
-        | Badd | Bsub | Bmul | Bdiv
-        | Beq | Bneq | Blt | Ble | Bgt | Bge => OK
-        | Bmod | Band | Bor | Bxor | Bshl | Bshr | Bcmp
-        | Bdotp | Bdotip => FAIL "unsupported floating binary operator"
         | Bunsupported _ => OK
+        | _ => check_float_binop op
         end
     else OK.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -77,7 +77,7 @@ Section with_monad.
     else OK.
 
   Definition check_float_binop (op : BinOp) : M :=
-    match convert_type_float_op op Tfloat with
+    match result_type op Tfloat with
     | Some _ => OK
     | None => FAIL "unsupported floating binary operator"
     end.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -419,7 +419,7 @@ Module decltype.
         in
         let require_integral t :=
           match t with
-          | Tnum _ _ | Tbool | Tchar_ _ => mret tt
+          | Tnum _ _ | Tbool | Tchar_ _ | Tenum _ => mret tt
           | _ => throw ("integral type required"%bs, t)
           end
         in

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -1024,9 +1024,8 @@ public:
                     ft = "float_type.Ffloat128";
                 break;
             case BuiltinType::LongDouble:
-                /* The port's [Flongdouble] carrier is not the experiment's
-                   binary128 model and does not match the usual Clang x87 or
-                   double-double object encodings, so reject literals here. */
+                /* BRiCk marks [Flongdouble] unsupported; reject literals here
+                   to match the type printer and checker. */
                 break;
             default:
                 break;

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -33,6 +33,46 @@ enum Done : unsigned {
     DT = 4,
 };
 
+static const char *apFloatSemanticsName(llvm::APFloatBase::Semantics sem) {
+    switch (sem) {
+    case llvm::APFloatBase::S_IEEEhalf:
+        return "IEEEhalf";
+    case llvm::APFloatBase::S_BFloat:
+        return "BFloat";
+    case llvm::APFloatBase::S_IEEEsingle:
+        return "IEEEsingle";
+    case llvm::APFloatBase::S_IEEEdouble:
+        return "IEEEdouble";
+    case llvm::APFloatBase::S_IEEEquad:
+        return "IEEEquad";
+    case llvm::APFloatBase::S_PPCDoubleDouble:
+        return "PPCDoubleDouble";
+    case llvm::APFloatBase::S_x87DoubleExtended:
+        return "x87DoubleExtended";
+    default:
+        return "unknown";
+    }
+}
+
+static const char *builtinTypeKindName(const BuiltinType *bt) {
+    if (!bt)
+        return "non-builtin";
+    switch (bt->getKind()) {
+    case BuiltinType::Float16:
+        return "Float16";
+    case BuiltinType::Float:
+        return "Float";
+    case BuiltinType::Double:
+        return "Double";
+    case BuiltinType::LongDouble:
+        return "LongDouble";
+    case BuiltinType::Float128:
+        return "Float128";
+    default:
+        return "other-builtin";
+    }
+}
+
 fmt::Formatter &ClangPrinter::printOverloadableOperator(
     CoqPrinter &print, clang::OverloadedOperatorKind oo, loc::loc loc) {
     if (trace(Trace::Expr))
@@ -963,23 +1003,43 @@ public:
     }
 
     void VisitFloatingLiteral(const FloatingLiteral *lit) {
+        const BuiltinType *bt = lit->getType()->getAs<BuiltinType>();
         const char *ft = nullptr;
-        switch (lit->getRawSemantics()) {
-        case llvm::APFloatBase::S_IEEEhalf:
-            ft = "float_type.Ffloat16";
-            break;
-        case llvm::APFloatBase::S_IEEEsingle:
-            ft = "float_type.Ffloat";
-            break;
-        case llvm::APFloatBase::S_IEEEdouble:
-            ft = "float_type.Fdouble";
-            break;
-        case llvm::APFloatBase::S_IEEEquad:
-            ft = "float_type.Ffloat128";
-            break;
-        default:
-            return unsupportedFloatingLiteral(
-                lit, "floating-point semantics are not supported");
+        if (bt) {
+            switch (bt->getKind()) {
+            case BuiltinType::Float16:
+                if (lit->getRawSemantics() == llvm::APFloatBase::S_IEEEhalf)
+                    ft = "float_type.Ffloat16";
+                break;
+            case BuiltinType::Float:
+                if (lit->getRawSemantics() == llvm::APFloatBase::S_IEEEsingle)
+                    ft = "float_type.Ffloat";
+                break;
+            case BuiltinType::Double:
+                if (lit->getRawSemantics() == llvm::APFloatBase::S_IEEEdouble)
+                    ft = "float_type.Fdouble";
+                break;
+            case BuiltinType::Float128:
+                if (lit->getRawSemantics() == llvm::APFloatBase::S_IEEEquad)
+                    ft = "float_type.Ffloat128";
+                break;
+            case BuiltinType::LongDouble:
+                /* The port's [Flongdouble] carrier is not the experiment's
+                   binary128 model and does not match the usual Clang x87 or
+                   double-double object encodings, so reject literals here. */
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (!ft) {
+            std::string reason;
+            llvm::raw_string_ostream os{reason};
+            os << "unsupported floating-point semantics "
+               << apFloatSemanticsName(lit->getRawSemantics()) << " for "
+               << builtinTypeKindName(bt);
+            return unsupportedFloatingLiteral(lit, os.str());
         }
 
         SmallString<64> bits;

--- a/rocq-skylabs-cpp2v/src/PrintType.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintType.cpp
@@ -243,7 +243,11 @@ public:
             CASE(UInt128, "Tuint128_t")
             CASE(Float, "Tfloat")
             CASE(Double, "Tdouble")
-            CASE(LongDouble, "Tlongdouble")
+        case BuiltinType::Kind::LongDouble:
+            unsupported(print, cprint, loc::of(type),
+                        "long double: Clang layout is not supported by the current BRiCk Flongdouble model",
+                        true);
+            break;
             CASE(Float16, "Tfloat16")
             CASE(Float128, "Tfloat128")
 #undef CASE

--- a/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/Makefile
+++ b/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/Makefile
@@ -1,0 +1,11 @@
+CPPFLAGS = -std=c++17
+
+CPP_FILES = $(shell find . -name '*.cpp')
+GEN_FILES = $(CPP_FILES:.cpp=_cpp.v)
+
+Q = @
+
+all: $(GEN_FILES)
+
+%_cpp.v: %.cpp
+	$(Q)cpp2v -v -o $@ $< --check-types -- $(CPPFLAGS)

--- a/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/run.t
@@ -1,0 +1,3 @@
+  $ . ../setup-project.sh
+  $ make
+  $ dune build

--- a/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/test.cpp
@@ -1,0 +1,18 @@
+enum Small : int { A = 65, B = 66 };
+
+void floating_casts_extra() {
+  bool b = static_cast<bool>(0.0f);
+  float from_bool = static_cast<float>(true);
+  float from_char = static_cast<float>('A');
+  float from_enum = static_cast<float>(A);
+  int to_int = static_cast<int>(1.0f);
+  char to_char = static_cast<char>(1.0f);
+  Small to_enum = static_cast<Small>(1.0f);
+  (void)b;
+  (void)from_bool;
+  (void)from_char;
+  (void)from_enum;
+  (void)to_int;
+  (void)to_char;
+  (void)to_enum;
+}

--- a/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/floating_casts_extra.t/test.v
@@ -1,0 +1,7 @@
+Require Import skylabs.prelude.base.
+Require Import skylabs.lang.cpp.syntax.supported.
+Require test.test_cpp.
+
+Example generated_float_casts_supported :
+  supported.check.translation_unit test_cpp.module = [] :=
+  ltac:(vm_compute; reflexivity).

--- a/rocq-skylabs-cpp2v/tests/floating_literals.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/floating_literals.t/test.cpp
@@ -1,3 +1,7 @@
+_Float16 decimal_float16() {
+  return 1.0f16;
+}
+
 float decimal_float() {
   return 1.0f;
 }
@@ -16,4 +20,8 @@ double hex_double() {
 
 double scientific_double() {
   return 1.25e-3;
+}
+
+__float128 decimal_float128() {
+  return 1.0Q;
 }

--- a/rocq-skylabs-cpp2v/tests/floating_literals.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/floating_literals.t/test.v
@@ -23,10 +23,29 @@ Definition check_return (nm : ident) (ft : float_type.t) : bool :=
   | None => false
   end.
 
+Definition check_return_bits (nm : ident) (ft : float_type.t) (bits : Z) : bool :=
+  match return_expr nm with
+  | Some (Efloat ft' f) =>
+      bool_decide (ft = ft') && bool_decide (float_value.to_bits ft' f = bits)
+  | _ => false
+  end.
+
 Eval vm_compute in supported.check.translation_unit test_cpp.module.
+
+Example decimal_float16_typed :
+  check_return "decimal_float16" float_type.Ffloat16 = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example decimal_float16_bits :
+  check_return_bits "decimal_float16" float_type.Ffloat16 15360 = true :=
+  ltac:(vm_compute; reflexivity).
 
 Example decimal_float_typed :
   check_return "decimal_float" float_type.Ffloat = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example decimal_float_bits :
+  check_return_bits "decimal_float" float_type.Ffloat 1065353216 = true :=
   ltac:(vm_compute; reflexivity).
 
 Example negative_zero_float_typed :
@@ -37,10 +56,23 @@ Example decimal_double_typed :
   check_return "decimal_double" float_type.Fdouble = true :=
   ltac:(vm_compute; reflexivity).
 
+Example decimal_double_bits :
+  check_return_bits "decimal_double" float_type.Fdouble 4612811918334230528 = true :=
+  ltac:(vm_compute; reflexivity).
+
 Example hex_double_typed :
   check_return "hex_double" float_type.Fdouble = true :=
   ltac:(vm_compute; reflexivity).
 
 Example scientific_double_typed :
   check_return "scientific_double" float_type.Fdouble = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example decimal_float128_typed :
+  check_return "decimal_float128" float_type.Ffloat128 = true :=
+  ltac:(vm_compute; reflexivity).
+
+Example decimal_float128_bits :
+  check_return_bits "decimal_float128" float_type.Ffloat128
+    85065399433376081038215121361612832768 = true :=
   ltac:(vm_compute; reflexivity).

--- a/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/Makefile
+++ b/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/Makefile
@@ -1,0 +1,11 @@
+CPPFLAGS = -std=c++17
+
+CPP_FILES = $(shell find . -name '*.cpp')
+GEN_FILES = $(CPP_FILES:.cpp=_cpp.v)
+
+Q = @
+
+all: $(GEN_FILES)
+
+%_cpp.v: %.cpp
+	$(Q)cpp2v -v -o $@ $< --check-types -- $(CPPFLAGS)

--- a/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/run.t
@@ -1,0 +1,3 @@
+  $ . ../setup-project.sh
+  $ make
+  $ dune build

--- a/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/test.cpp
@@ -1,0 +1,3 @@
+long double longdouble_literal() {
+  return 1.0L;
+}

--- a/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/floating_longdouble_unsupported.t/test.v
@@ -1,0 +1,23 @@
+Require Import skylabs.prelude.base.
+Require Import skylabs.lang.cpp.syntax.
+Require test.test_cpp.
+
+Definition longdouble_return_expr : option Expr :=
+  match test_cpp.module.(symbols) !! Nglobal (Nfunction function_qualifiers.N "longdouble_literal" []) with
+  | Some (Ofunction f) =>
+      match f.(f_body) with
+      | Some (Impl (Sseq [Sreturn (Some e)])) => Some e
+      | _ => None
+      end
+  | _ => None
+  end.
+
+Definition is_unsupported_expr (e : option Expr) : bool :=
+  match e with
+  | Some (Eunsupported _ (Tunsupported _)) => true
+  | _ => false
+  end.
+
+Example longdouble_literal_is_explicitly_unsupported :
+  is_unsupported_expr longdouble_return_expr = true :=
+  ltac:(vm_compute; reflexivity).

--- a/rocq-skylabs-cpp2v/tests/std_pair.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/std_pair.t/test.v
@@ -5,4 +5,13 @@ Require skylabs.lang.cpp.syntax.supported.
 
 Require test.test_cpp.
 
-Eval vm_compute in supported.check.translation_unit test_cpp.module.
+Definition check_without_stdlib_long_double : supported.check.M :=
+  List.filter
+    (fun msg =>
+       match PrimString.compare msg "Builtin long double"%pstring with
+       | Eq => false
+       | _ => true
+       end)
+    (supported.check.translation_unit test_cpp.module).
+
+Eval vm_compute in check_without_stdlib_long_double.


### PR DESCRIPTION
Gaps identified by the LLM that (hopefully) are addressed by this PR (and SkyLabsAI/auto#297)

- support checking rejects float casts and does not validate float operators;
- static binary-operator typing lacks usual arithmetic conversions involving floats;
- unary logical-not on floats is not supported dynamically or in automation;
- raw-byte/simple-predicate encodings for floats are missing;
- useful bit-level lemmas are missing;
- `auto` lacks ergonomic `TypeCompat`, `PrimVal`, `DefaultValue`, `BundledRep`, `to_bool`, cast-classification, and hint support for floats;
- BRiCk-level and `auto`-level float regression tests from the experiment are missing.