### PR TITLE
Extend float theory

### DIFF
--- a/rocq-skylabs-brick/tests/float_simple_pred_support.v
+++ b/rocq-skylabs-brick/tests/float_simple_pred_support.v
@@ -36,7 +36,7 @@ Section pure_encoding_tests.
     rewrite /pure_encodes /=.
     split; [reflexivity|].
     split.
-    - replace (float_value.to_bits float_type.Ffloat16 f16_one) with f16_one_bits.
+    - replace (float_value.to_bits f16_one) with f16_one_bits.
       + rewrite /in_Z_to_bytes_bounds /f16_one_bits /=.
         change (0 <= 15360 /\ 15360 < 65536)%Z. lia.
       + symmetry. apply float_value.to_of_bits. change (0 <= 15360 < 65536)%Z. lia.
@@ -50,7 +50,7 @@ Section pure_encoding_tests.
     rewrite /pure_encodes /=.
     split; [reflexivity|].
     split.
-    - replace (float_value.to_bits float_type.Ffloat f32_one) with f32_one_bits.
+    - replace (float_value.to_bits f32_one) with f32_one_bits.
       + rewrite /in_Z_to_bytes_bounds /f32_one_bits /=.
         change (0 <= 1065353216 /\ 1065353216 < 4294967296)%Z. lia.
       + symmetry. apply float_value.to_of_bits.
@@ -65,7 +65,7 @@ Section pure_encoding_tests.
     rewrite /pure_encodes /=.
     split; [reflexivity|].
     split.
-    - replace (float_value.to_bits float_type.Ffloat128 f128_one) with f128_one_bits.
+    - replace (float_value.to_bits f128_one) with f128_one_bits.
       + rewrite /in_Z_to_bytes_bounds /f128_one_bits /=.
         change (0 <= 85065399433376081038215121361612832768 /\
                 85065399433376081038215121361612832768 <

--- a/rocq-skylabs-brick/tests/float_support.v
+++ b/rocq-skylabs-brick/tests/float_support.v
@@ -268,17 +268,17 @@ Qed.
 
 Example float_to_of_bits_roundtrips bits :
   (0 <= bits < 2 ^ float_type.bit_width float_type.Ffloat)%Z ->
-  float_value.to_bits float_type.Ffloat
+  float_value.to_bits
     (float_value.of_bits float_type.Ffloat bits) = bits.
 Proof. apply float_value.to_of_bits. Qed.
 
-Example double_of_to_bits_roundtrip f :
+Example double_of_to_bits_roundtrip (f : float_type.car float_type.Fdouble) :
   float_value.of_bits float_type.Fdouble
-    (float_value.to_bits float_type.Fdouble f) = f.
+    (float_value.to_bits f) = f.
 Proof. apply float_value.of_to_bits. Qed.
 
 Example float128_nan_payload_bits_preserved :
-  float_value.to_bits float_type.Ffloat128 f128_nan_payload = f128_nan_payload_bits.
+  float_value.to_bits f128_nan_payload = f128_nan_payload_bits.
 Proof.
   apply float_value.to_of_bits.
   change (0 <= 170138587312039964317873038467719495681 <
@@ -356,16 +356,16 @@ Proof.
 Qed.
 
 Example float_nan_compare_unordered :
-  float_value.value_compare float_type.Ffloat f32_nan f32_nan = None.
+  float_value.value_compare f32_nan f32_nan = None.
 Proof. vm_compute; reflexivity. Qed.
 
 Example double_nan_compare_unordered :
-  float_value.value_compare float_type.Fdouble f64_nan f64_nan = None.
+  float_value.value_compare f64_nan f64_nan = None.
 Proof. vm_compute; reflexivity. Qed.
 
 Example float_nan_payload_add_preserved :
-  float_value.to_bits float_type.Ffloat
-    (float_value.add float_type.Ffloat f32_nan_payload f32_one) =
+  float_value.to_bits
+    (float_value.add f32_nan_payload f32_one) =
   f32_nan_payload_bits.
 Proof. vm_compute; reflexivity. Qed.
 
@@ -383,22 +383,22 @@ Proof. vm_compute; reflexivity. Qed.
 
 Example raw_float16_intro {σ : genv} :
   raw_bytes_of_val σ Tfloat16 (Vfloat float_type.Ffloat16 f16_one)
-    (float_raw_bytes σ float_type.Ffloat16 f16_one).
+    (float_raw_bytes σ f16_one).
 Proof. apply raw_bytes_of_val_float_intro. Qed.
 
 Example raw_float_intro {σ : genv} :
   raw_bytes_of_val σ Tfloat (Vfloat float_type.Ffloat f32_one)
-    (float_raw_bytes σ float_type.Ffloat f32_one).
+    (float_raw_bytes σ f32_one).
 Proof. apply raw_bytes_of_val_float_intro. Qed.
 
 Example raw_double_intro {σ : genv} :
   raw_bytes_of_val σ Tdouble (Vfloat float_type.Fdouble f64_one)
-    (float_raw_bytes σ float_type.Fdouble f64_one).
+    (float_raw_bytes σ f64_one).
 Proof. apply raw_bytes_of_val_float_intro. Qed.
 
 Example raw_float128_intro {σ : genv} :
   raw_bytes_of_val σ Tfloat128 (Vfloat float_type.Ffloat128 f128_one)
-    (float_raw_bytes σ float_type.Ffloat128 f128_one).
+    (float_raw_bytes σ f128_one).
 Proof. apply raw_bytes_of_val_float_intro. Qed.
 
 Example float16_bits_compatible :
@@ -422,7 +422,7 @@ Example longdouble_raw_bits_not_binary128_compatible :
 Proof. intros [_ Hwidth]. vm_compute in Hwidth. discriminate. Qed.
 
 Example float_to_bits_has_unsigned_type {σ : genv} :
-  has_type_prop (Vint (float_value.to_bits float_type.Ffloat f32_one))
+  has_type_prop (Vint (float_value.to_bits f32_one))
     (Tnum int_rank.Iint Unsigned).
 Proof.
   apply float_to_bits_has_type_unsigned.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/raw.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/raw.v
@@ -66,12 +66,12 @@ Axiom raw_byte_of_int_eq : ∀ {σ : genv} sz x rs,
   ∃ l, decodes_uint l x /\ raw_int_byte <$> l = rs /\ length l = N.to_nat (int_rank.bytesN sz).
 
 Lemma raw_bytes_of_val_float_intro {σ : genv} ft (f : float_type.car ft) :
-  raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) (float_raw_bytes σ ft f).
+  raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) (float_raw_bytes σ f).
 Proof. apply raw_bytes_of_val_float. reflexivity. Qed.
 
 Lemma raw_bytes_of_val_float_elim {σ : genv} ft (f : float_type.car ft) rs :
   raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs ->
-  rs = float_raw_bytes σ ft f.
+  rs = float_raw_bytes σ f.
 Proof. apply raw_bytes_of_val_float. Qed.
 
 Definition float_bits_compatible (sz : int_rank.t) (ft : float_type.t) : Prop :=
@@ -87,7 +87,7 @@ Qed.
 
 Lemma float_to_bits_has_type_unsigned {σ : genv} sz ft (f : float_type.car ft) :
   float_bits_compatible sz ft ->
-  has_type_prop (Vint (float_value.to_bits ft f)) (Tnum sz Unsigned).
+  has_type_prop (Vint (float_value.to_bits f)) (Tnum sz Unsigned).
 Proof.
   intros [Hbits Hwidth].
   rewrite -has_int_type.

--- a/rocq-skylabs-brick/theories/lang/cpp/model/simple_pred.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/simple_pred.v
@@ -430,8 +430,8 @@ Module SimpleCPP.
           match v with
           | Vfloat ft' f =>
               ft = ft' /\
-              in_Z_to_bytes_bounds (float_type.bitsize ft') Unsigned (float_value.to_bits ft' f) /\
-              vs = Z_to_bytes (float_type.bitsize ft') Unsigned (float_value.to_bits ft' f)
+              in_Z_to_bytes_bounds (float_type.bitsize ft') Unsigned (float_value.to_bits f) /\
+              vs = Z_to_bytes (float_type.bitsize ft') Unsigned (float_value.to_bits f)
           | Vundef => pure_encodes_undef (float_type.bitsize ft) vs
           | _ => False
           end

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/cast.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/cast.v
@@ -296,7 +296,7 @@ Definition conv_float {σ : genv} (tu : translation_unit) (from to : type) (v v'
   | Tfloat_ _ , Tnum _ _ =>
       match v with
       | Vfloat f z =>
-          match float_value.to_int f z with
+          match float_value.to_int z with
           | Some n => v' = Vint n /\ has_type_prop (Vint n) to
           | None => False
           end
@@ -432,7 +432,7 @@ Section conv_float.
 
   Lemma conv_float_to_int ty sz sgn ft (fv : float_type.car ft) z :
       representation_type tu ty = Tnum sz sgn ->
-      float_value.to_int ft fv = Some z ->
+      float_value.to_int fv = Some z ->
       has_type_prop (Vint z) ty ->
       conv_float tu (Tfloat_ ft) ty (Vfloat ft fv) (Vint z).
   Proof using Hmod.
@@ -459,7 +459,7 @@ Section conv_float.
 
   Lemma conv_float_to_enum nm sz sgn ft (fv : float_type.car ft) z :
       representation_type tu (Tenum nm) = Tnum sz sgn ->
-      float_value.to_int ft fv = Some z ->
+      float_value.to_int fv = Some z ->
       has_type_prop (Vint z) (Tenum nm) ->
       conv_float tu (Tfloat_ ft) (Tenum nm) (Vfloat ft fv) (Vint z).
   Proof using Hmod.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/characters.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/characters.v
@@ -70,7 +70,7 @@ Definition Z_to_char_bits (ct : char_type.t) (z : Z) : N :=
 
 Definition float_to_char (σ : genv) (ft : float_type.t) (ct : char_type.t)
     (f : float_type.car ft) : option N :=
-  match float_value.to_int ft f with
+  match float_value.to_int f with
   | Some z => if char_float_boundb σ ct z then Some (Z_to_char_bits ct z) else None
   | None => None
   end.
@@ -450,7 +450,7 @@ Lemma float_to_char_has_type {σ : genv} ft ct (f : float_type.car ft) n :
   has_type_prop (Vchar n) (Tchar_ ct).
 Proof.
   rewrite /float_to_char.
-  destruct (float_value.to_int ft f) as [z|] eqn:HtoZ; try discriminate.
+  destruct (float_value.to_int f) as [z|] eqn:HtoZ; try discriminate.
   destruct (char_float_boundb σ ct z) eqn:Hbound; inversion 1; subst.
   apply has_type_prop_char'.
   apply Z_to_char_bits_bounded.

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/operator.v
@@ -151,7 +151,7 @@ Axiom eval_minus_int : forall ty a c,
     eval_unop Uminus ty ty (Vint a) (Vint c).
 Axiom eval_minus_float : forall f a,
     eval_unop Uminus (Tfloat_ f) (Tfloat_ f)
-      (Vfloat f a) (Vfloat f (float_value.opp f a)).
+      (Vfloat f a) (Vfloat f (float_value.opp a)).
 
 (** * Binary Operators *)
 
@@ -194,10 +194,10 @@ Let eval_float_op (bo : BinOp)
     eval_binop_pure bo (Tfloat_ f) (Tfloat_ f) (Tfloat_ f)
       (Vfloat f a) (Vfloat f b) (Vfloat f c).
 
-Axiom eval_float_add : Hnf (eval_float_op Badd float_value.add).
-Axiom eval_float_sub : Hnf (eval_float_op Bsub float_value.sub).
-Axiom eval_float_mul : Hnf (eval_float_op Bmul float_value.mul).
-Axiom eval_float_div : Hnf (eval_float_op Bdiv float_value.div).
+Axiom eval_float_add : Hnf (eval_float_op Badd (@float_value.add)).
+Axiom eval_float_sub : Hnf (eval_float_op Bsub (@float_value.sub)).
+Axiom eval_float_mul : Hnf (eval_float_op Bmul (@float_value.mul)).
+Axiom eval_float_div : Hnf (eval_float_op Bdiv (@float_value.div)).
 
 (* The binary operator / divides the first operand by the second, after usual
    arithmetic conversions.
@@ -418,12 +418,12 @@ Arguments eval_ge _ {_}.
     eval_binop_pure bo (Tfloat_ f) (Tfloat_ f) ty'
       (Vfloat f av) (Vfloat f bv) (Vbool (o f av bv)).
 
-Axiom eval_float_eq : Hnf (eval_float_rel_op float_value.eqb Beq).
-Axiom eval_float_neq : Hnf (eval_float_rel_op float_value.neqb Bneq).
-Axiom eval_float_lt : Hnf (eval_float_rel_op float_value.ltb Blt).
-Axiom eval_float_gt : Hnf (eval_float_rel_op float_value.gtb Bgt).
-Axiom eval_float_le : Hnf (eval_float_rel_op float_value.leb Ble).
-Axiom eval_float_ge : Hnf (eval_float_rel_op float_value.geb Bge).
+Axiom eval_float_eq  : Hnf (eval_float_rel_op (@float_value.eqb) Beq).
+Axiom eval_float_neq : Hnf (eval_float_rel_op (@float_value.neqb) Bneq).
+Axiom eval_float_lt  : Hnf (eval_float_rel_op (@float_value.ltb) Blt).
+Axiom eval_float_gt  : Hnf (eval_float_rel_op (@float_value.gtb) Bgt).
+Axiom eval_float_le  : Hnf (eval_float_rel_op (@float_value.leb) Ble).
+Axiom eval_float_ge  : Hnf (eval_float_rel_op (@float_value.geb) Bge).
 
 (* Special cases for <decltype(nullptr)> because they are not generally comparable *)
 Axiom eval_eq_nullptr :

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
@@ -242,12 +242,12 @@ Module Type RAW_BYTES_VAL
   Axiom raw_bytes_of_val_sizeof : forall {σ ty v rs},
       raw_bytes_of_val σ ty v rs -> size_of σ ty = Some (N.of_nat $ length rs).
 
-  Definition float_raw_bytes (σ : genv) ft (f : float_type.car ft) : list raw_byte :=
+  Definition float_raw_bytes (σ : genv) {ft} (f : float_type.car ft) : list raw_byte :=
     raw_int_byte <$> _Z_to_bytes (N.to_nat (float_type.bytesN ft))
-      (genv_byte_order σ) Unsigned (float_value.to_bits ft f).
+      (genv_byte_order σ) Unsigned (float_value.to_bits f).
 
   Lemma float_raw_bytes_length σ ft (f : float_type.car ft) :
-    length (float_raw_bytes σ ft f) = N.to_nat (float_type.bytesN ft).
+    length (float_raw_bytes σ f) = N.to_nat (float_type.bytesN ft).
   Proof. by rewrite /float_raw_bytes length_fmap _Z_to_bytes_length. Qed.
 
   (** Float raw-byte support is intentionally narrow: the byte sequence is the
@@ -255,10 +255,10 @@ Module Type RAW_BYTES_VAL
       such encodings for values of the same float type determines the value. *)
   Axiom raw_bytes_of_val_float : forall {σ ft} (f : float_type.car ft) rs,
       raw_bytes_of_val σ (Tfloat_ ft) (Vfloat ft f) rs <->
-      rs = float_raw_bytes σ ft f.
+      rs = float_raw_bytes σ f.
 
   #[global] Declare Instance float_raw_bytes_inj : forall {σ ft},
-      Inj (=) (=) (float_raw_bytes σ ft).
+      Inj (=) (=) (float_raw_bytes σ (ft := ft)).
 
   (* TODO Maybe add?
     Axiom raw_bytes_of_val_int : forall σ sz z rs,

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -1962,7 +1962,7 @@ Module Expr.
       | Eunresolved_string_literal t => t
       | Eint n t => Box_Eint n t
       | Ebool b => b
-      | Efloat ft v => Box_Efloat ft (float_value.to_bits ft v)
+      | Efloat ft v => Box_Efloat ft (float_value.to_bits v)
       | Eunop op e t => Box_Eunop op e t
       | Ebinop op l r t => Box_Ebinop op l r t
       | Ederef e t => Box_Ederef e t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -686,38 +686,24 @@ Module float_value.
   Definition div (t : t) : car t -> car t -> car t := div_with_mode BinarySingleNaN.mode_NE t.
 
   Definition value_compare (t : t) : car t -> car t -> option comparison :=
-    match t return car t -> car t -> option comparison with
-    | Ffloat16 => Bcompare _ _
-    | Ffloat => Bcompare _ _
-    | Fdouble => Bcompare _ _
-    | Flongdouble => Bcompare _ _
-    | Ffloat128 => Bcompare _ _
-    end.
+    Bcompare _ _.
 
   Lemma value_compare_antisym ft (x y : car ft) :
     value_compare ft y x = CompOpp <$> value_compare ft x y.
-  Proof. by destruct ft; apply Bcompare_swap. Qed.
+  Proof. apply Bcompare_swap. Qed.
 
   Definition eqb (t : t) (v1 v2 : car t) : bool :=
-    match value_compare t v1 v2 with
-    | Some Eq => true
-    | _ => false
-    end.
+    bool_decide (value_compare t v1 v2 = Some Eq).
 
   Definition neqb (t : t) (v1 v2 : car t) : bool :=
     negb (eqb t v1 v2).
 
   Definition ltb (t : t) (v1 v2 : car t) : bool :=
-    match value_compare t v1 v2 with
-    | Some Lt => true
-    | _ => false
-    end.
+    bool_decide (value_compare t v1 v2 = Some Lt).
 
   Definition leb (t : t) (v1 v2 : car t) : bool :=
-    match value_compare t v1 v2 with
-    | Some Lt | Some Eq => true
-    | _ => false
-    end.
+    let cmp := value_compare t v1 v2 in
+    bool_decide (cmp = Some Lt \/ cmp = Some Eq).
 
   Definition gtb (t : t) (v1 v2 : car t) : bool :=
     ltb t v2 v1.
@@ -741,24 +727,14 @@ Module float_value.
   Lemma to_bits_range ft (f : car ft) :
     (0 <= to_bits ft f < 2 ^ float_type.bit_width ft)%Z.
   Proof.
-    destruct ft; simpl in *.
-    - exact (bits_of_binary_float_range 10 5 ltac:(lia) ltac:(lia) f).
-    - exact (bits_of_binary_float_range 23 8 ltac:(lia) ltac:(lia) f).
-    - exact (bits_of_binary_float_range 52 11 ltac:(lia) ltac:(lia) f).
-    - exact (bits_of_binary_float_range 63 15 ltac:(lia) ltac:(lia) f).
-    - exact (bits_of_binary_float_range 112 15 ltac:(lia) ltac:(lia) f).
+    destruct ft; simpl in *; apply bits_of_binary_float_range; lia.
   Qed.
 
   Lemma to_of_bits ft z :
     (0 <= z < 2 ^ float_type.bit_width ft)%Z ->
     to_bits ft (of_bits ft z) = z.
   Proof.
-    destruct ft; simpl; intros Hz.
-    - exact (bits_of_binary_float_of_bits 10 5 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
-    - exact (bits_of_binary_float_of_bits 23 8 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
-    - exact (bits_of_binary_float_of_bits 52 11 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
-    - exact (bits_of_binary_float_of_bits 63 15 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
-    - exact (bits_of_binary_float_of_bits 112 15 (refl_equal _) (refl_equal _) (refl_equal _) z Hz).
+    destruct ft; simpl; intros Hz; exact: bits_of_binary_float_of_bits.
   Qed.
 
   Lemma to_of_bits_Ffloat16 z :
@@ -829,7 +805,7 @@ Module float_value.
       | H : Pcompare _ _ Eq = Eq |- _ => apply Pos.compare_eq in H; subst
       | H : Eq = Pcompare _ _ Eq |- _ => symmetry in H; apply Pos.compare_eq in H; subst
       end;
-      left; f_equal; apply Eqdep_dec.UIP_dec; decide equality.
+      left; f_equal; apply: proof_irrel.
   Qed.
 
   Lemma value_compare_eq_nonzero ft (x y : car ft) :

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -694,6 +694,10 @@ Module float_value.
     | Ffloat128 => Bcompare _ _
     end.
 
+  Lemma value_compare_antisym ft (x y : car ft) :
+    value_compare ft y x = CompOpp <$> value_compare ft x y.
+  Proof. by destruct ft; apply Bcompare_swap. Qed.
+
   Definition eqb (t : t) (v1 v2 : car t) : bool :=
     match value_compare t v1 v2 with
     | Some Eq => true
@@ -730,6 +734,9 @@ Module float_value.
     - exact (binary_float_of_bits_of_binary_float 63 15 (refl_equal _) (refl_equal _) (refl_equal _) f).
     - exact (binary_float_of_bits_of_binary_float 112 15 (refl_equal _) (refl_equal _) (refl_equal _) f).
   Qed.
+
+  #[global] Instance of_to_bits_cancel ft : Cancel (=) (of_bits ft) (to_bits ft) :=
+    of_to_bits ft.
 
   Lemma to_bits_range ft (f : car ft) :
     (0 <= to_bits ft f < 2 ^ float_type.bit_width ft)%Z.
@@ -770,11 +777,89 @@ Module float_value.
     (0 <= z < 2 ^ 128)%Z -> to_bits Ffloat128 (of_bits Ffloat128 z) = z.
   Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
 
-  #[global] Instance to_bits_inj ft : Inj (=) (=) (to_bits ft).
+  #[global] Instance to_bits_inj ft : Inj (=) (=) (to_bits ft) := cancel_inj.
+
+  Lemma value_compare_zero_zero ft (x y : car ft) :
+    is_zero x = true -> is_zero y = true -> value_compare ft x y = Some Eq.
   Proof.
-    intros x y Hbits.
-    apply (f_equal (of_bits ft)) in Hbits.
-    by rewrite !of_to_bits in Hbits.
+    destruct ft; destruct x; destruct y; cbn; congruence.
+  Qed.
+
+  Lemma value_compare_eq_or_zeros ft (x y : car ft) :
+    value_compare ft x y = Some Eq -> x = y ∨ is_zero x = true ∧ is_zero y = true.
+  Proof.
+    destruct ft; destruct x as [sx|sx|sx px Hpx|sx mx ex Hx];
+      destruct y as [sy|sy|sy py Hpy|sy my ey Hy]; cbn in *; try congruence.
+    all: try (right; done).
+    all: try (by destruct sx, sy; cbn in *; simplify_eq; left).
+    all: destruct sx, sy; cbn in *; try congruence;
+      repeat case_match; simplify_eq; try congruence;
+      try match goal with
+      | mx : positive, my : positive |- _ =>
+          destruct (Pos.compare_cont Eq mx my) eqn:?; cbn in *; simplify_eq; try congruence
+      end;
+      repeat match goal with
+      | H : Some (CompOpp (Pos.compare_cont Eq ?x ?y)) = Some Eq |- _ =>
+          let Hxy := fresh in
+          assert (Hxy : Pos.compare_cont Eq x y = Eq) by
+            (destruct (Pos.compare_cont Eq x y); cbn in H; congruence);
+          clear H
+      | H : CompOpp (Pos.compare_cont Eq ?x ?y) = Eq |- _ =>
+          let Hxy := fresh in
+          assert (Hxy : Pos.compare_cont Eq x y = Eq) by
+            (destruct (Pos.compare_cont Eq x y); cbn in H; congruence);
+          clear H
+      | H : Some (CompOpp (Pcompare ?x ?y Eq)) = Some Eq |- _ =>
+          let Hxy := fresh in
+          assert (Hxy : Pcompare x y Eq = Eq) by
+            (destruct (Pcompare x y Eq); cbn in H; congruence);
+          clear H
+      | H : CompOpp (Pcompare ?x ?y Eq) = Eq |- _ =>
+          let Hxy := fresh in
+          assert (Hxy : Pcompare x y Eq = Eq) by
+            (destruct (Pcompare x y Eq); cbn in H; congruence);
+          clear H
+      | H : Some (CompOpp ?c) = Some Eq |- _ => destruct c eqn:?; simplify_eq
+      | H : CompOpp ?c = Eq |- _ => destruct c eqn:?; simplify_eq
+      end;
+      repeat match goal with
+      | H : Z.compare _ _ = Eq |- _ => apply Z.compare_eq in H; subst
+      | H : Eq = Z.compare _ _ |- _ => symmetry in H; apply Z.compare_eq in H; subst
+      | H : Pos.compare_cont Eq _ _ = Eq |- _ => apply Pcompare_Eq_eq in H; subst
+      | H : Pcompare _ _ Eq = Eq |- _ => apply Pos.compare_eq in H; subst
+      | H : Eq = Pcompare _ _ Eq |- _ => symmetry in H; apply Pos.compare_eq in H; subst
+      end;
+      left; f_equal; apply Eqdep_dec.UIP_dec; decide equality.
+  Qed.
+
+  Lemma value_compare_eq_nonzero ft (x y : car ft) :
+    value_compare ft x y = Some Eq ->
+    is_zero x = false -> is_zero y = false -> x = y.
+  Proof.
+    move=> /value_compare_eq_or_zeros [//|[Hx _]] Hnz _.
+    by rewrite Hx in Hnz.
+  Qed.
+
+  Lemma value_compare_eq_B2R ft (x y : car ft) :
+    value_compare ft x y = Some Eq -> B2R _ _ x = B2R _ _ y.
+  Proof.
+    move=> /value_compare_eq_or_zeros [->|[Hx Hy]]; [done|].
+    destruct ft; destruct x; destruct y; cbn in *; congruence.
+  Qed.
+
+  Lemma value_compare_eq_sym ft (x y : car ft) :
+    value_compare ft x y = Some Eq -> value_compare ft y x = Some Eq.
+  Proof. by move=> H; rewrite value_compare_antisym H. Qed.
+
+  Lemma value_compare_eq_trans ft (x y z : car ft) :
+    value_compare ft x y = Some Eq ->
+    value_compare ft y z = Some Eq ->
+    value_compare ft x z = Some Eq.
+  Proof.
+    intros Hxy Hyz.
+    destruct (value_compare_eq_or_zeros _ _ _ Hxy) as [->|[Hx Hy]]; [done|].
+    destruct (value_compare_eq_or_zeros _ _ _ Hyz) as [<-|[_ Hz]]; [done|].
+    by apply value_compare_zero_zero.
   Qed.
 
 End float_value.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -252,8 +252,8 @@ Module char_type.
     abstract (by intros []).
   Defined.
 
-  Definition bytesN (t : t) : N :=
-    match t with
+  Definition bytesN (ct : t) : N :=
+    match ct with
     | Cchar => 1
     | Cwchar => 4 (* TODO: actually 16-bits on Windows *)
     | C8 => 1
@@ -262,8 +262,8 @@ Module char_type.
     end.
   #[global] Arguments bytesN !_ /.
 
-  Definition bitsN (t : t) : N :=
-    8 * bytesN t.
+  Definition bitsN (ct : t) : N :=
+    8 * bytesN ct.
   #[global] Arguments bitsN !_ /.
 
   #[global] Notation bitsZ t := (Z.of_N (bitsN t)).
@@ -307,8 +307,8 @@ Module int_rank.
   Definition ranks :=
     [Ichar; Ishort; Iint; Ilong; Ilonglong; I128].
 
-  Definition bitsize (t : t) : bitsize :=
-    match t with
+  Definition bitsize (ir : t) : bitsize :=
+    match ir with
     | Ichar => bitsize.W8
     | Ishort => bitsize.W16
     | Iint => bitsize.W32
@@ -318,8 +318,8 @@ Module int_rank.
     end.
 
   (* Having this definition not contain multiplication is helpful *)
-  Definition bytesN (t : t) : N :=
-    match t with
+  Definition bytesN (ir : t) : N :=
+    match ir with
     | Ichar => Evaluate (bitsize.bytesN $ bitsize Ichar)
     | Ishort  => Evaluate (bitsize.bytesN $ bitsize Ishort)
     | Iint  => Evaluate (bitsize.bytesN $ bitsize Iint)
@@ -327,17 +327,17 @@ Module int_rank.
     | Ilonglong  => Evaluate (bitsize.bytesN $ bitsize Ilonglong)
     | I128  => Evaluate (bitsize.bytesN $ bitsize I128)
     end.
-  Lemma bytesN_ok (t : t) :
-    bytesN t = bitsize.bytesN (bitsize t).
-  Proof. by destruct t. Qed.
+  Lemma bytesN_ok (ir : t) :
+    bytesN ir = bitsize.bytesN (bitsize ir).
+  Proof. by destruct ir. Qed.
 
   Notation bytesNat t := (N.to_nat (bytesN t)) (only parsing).
-  Lemma bytesNat_ok (t : t) :
-    bytesNat t = bitsize.bytesNat (bitsize t).
-  Proof. by destruct t. Qed.
+  Lemma bytesNat_ok (ir : t) :
+    bytesNat ir = bitsize.bytesNat (bitsize ir).
+  Proof. by destruct ir. Qed.
 
-  Definition bitsN (t : t) : N :=
-    match t with
+  Definition bitsN (ir : t) : N :=
+    match ir with
     | Ichar => Evaluate (8 * bytesN Ichar)
     | Ishort => Evaluate (8 * bytesN Ishort)
     | Iint => Evaluate (8 * bytesN Iint)
@@ -414,8 +414,8 @@ Module float_type.
     abstract (by intros []).
   Defined.
 
-  Definition bytesN (t : t) : N :=
-    match t with
+  Definition bytesN (ft : t) : N :=
+    match ft with
     | Ffloat16 => 2
     | Ffloat => 4
     | Fdouble => 8
@@ -423,12 +423,12 @@ Module float_type.
     | Ffloat128 => Evaluate (128 / 8)%N
     end.
 
-  Definition bitsN (t : t) : N :=
-    8 * bytesN t.
+  Definition bitsN (ft : t) : N :=
+    8 * bytesN ft.
 
   (** Frontend/checker support predicate. *)
-  Definition supported (t : t) : bool :=
-    match t with
+  Definition supported (ft : t) : bool :=
+    match ft with
     | Flongdouble => false
     | _ => true
     end.
@@ -436,21 +436,21 @@ Module float_type.
   (** Object-representation size when it is one of BRiCk's fixed integer
       bit-widths.  For [Flongdouble], this is the 16-byte object size; its
       Flocq bit encoding below has a smaller [bit_width]. *)
-  Definition bitsize (t : t) : bitsize.t :=
-    match t with
+  Definition bitsize (ft : t) : bitsize.t :=
+    match ft with
     | Ffloat16 => bitsize.W16
     | Ffloat => bitsize.W32
     | Fdouble => bitsize.W64
     | Flongdouble | Ffloat128 => bitsize.W128
     end.
 
-  Lemma bitsize_bytesN (t : t) :
-    bitsize.bytesN (bitsize t) = bytesN t.
-  Proof. by destruct t. Qed.
+  Lemma bitsize_bytesN (ft : t) :
+    bitsize.bytesN (bitsize ft) = bytesN ft.
+  Proof. by destruct ft. Qed.
 
-  Lemma bitsize_bitsN (t : t) :
-    bitsize.bitsN (bitsize t) = bitsN t.
-  Proof. by destruct t. Qed.
+  Lemma bitsize_bitsN (ft : t) :
+    bitsize.bitsN (bitsize ft) = bitsN ft.
+  Proof. by destruct ft. Qed.
 
   (** Parameters for [binary_float].
 
@@ -458,8 +458,8 @@ Module float_type.
       for normalized finite values. [ew] is the exponent bound parameter used
       by [binary_float].
    *)
-  Definition mw (t : t) : Z :=
-    match t with
+  Definition mw (ft : t) : Z :=
+    match ft with
     | Ffloat16 => 11
     | Ffloat => 24
     | Fdouble => 53
@@ -467,11 +467,11 @@ Module float_type.
     | Ffloat128 => 113
     end.
 
-  Lemma mw_gt_0 (t : t) : (0 < mw t)%Z.
-  Proof. by destruct t. Qed.
+  Lemma mw_gt_0 (ft : t) : (0 < mw ft)%Z.
+  Proof. by destruct ft. Qed.
 
-  Definition ew (t : t) : Z :=
-    match t with
+  Definition ew (ft : t) : Z :=
+    match ft with
     | Ffloat16 => 16
     | Ffloat => 128
     | Fdouble => 1024
@@ -479,8 +479,8 @@ Module float_type.
     | Ffloat128 => 16384
     end.
 
-  Lemma mw_lt_ew (t : t) : (mw t < ew t)%Z.
-  Proof. by destruct t. Qed.
+  Lemma mw_lt_ew (ft : t) : (mw ft < ew ft)%Z.
+  Proof. by destruct ft. Qed.
 
 
   (** Parameters for the IEEE bit encoding helpers.
@@ -493,24 +493,24 @@ Module float_type.
       The [binary_float] exponent parameter is [2 ^ (ebits - 1)], so the
       stored exponent width is recovered from [ew].
    *)
-  Definition fraction_bits (t : t) : Z := mw t - 1.
-  Definition exponent_bits (t : t) : Z := Z.log2 (ew t) + 1.
-  Definition bit_width (t : t) : Z := 1 + fraction_bits t + exponent_bits t.
+  Definition fraction_bits (ft : t) : Z := mw ft - 1.
+  Definition exponent_bits (ft : t) : Z := Z.log2 (ew ft) + 1.
+  Definition bit_width (ft : t) : Z := 1 + fraction_bits ft + exponent_bits ft.
 
-  Lemma bit_width_nonnegative (t : t) : (0 <= bit_width t)%Z.
-  Proof. by destruct t. Qed.
+  Lemma bit_width_nonnegative (ft : t) : (0 <= bit_width ft)%Z.
+  Proof. by destruct ft. Qed.
 
-  Lemma bit_width_le_bitsN (t : t) :
-    (bit_width t <= Z.of_N (bitsN t))%Z.
-  Proof. by destruct t. Qed.
+  Lemma bit_width_le_bitsN (ft : t) :
+    (bit_width ft <= Z.of_N (bitsN ft))%Z.
+  Proof. by destruct ft. Qed.
 
-  Lemma bit_width_bitsize_not_longdouble (t : t) :
-    t <> Flongdouble -> bit_width t = bitsize.bitsZ (bitsize t).
-  Proof. by destruct t. Qed.
+  Lemma bit_width_bitsize_not_longdouble (ft : t) :
+    ft <> Flongdouble -> bit_width ft = bitsize.bitsZ (bitsize ft).
+  Proof. by destruct ft. Qed.
 
   (** The carrier type *)
-  Definition car (t : t) : Set :=
-    binary_float (mw t) (ew t).
+  Definition car (ft : t) : Set :=
+    binary_float (mw ft) (ew ft).
 
   #[global] Instance full_float_dec : EqDecision full_float.
   Proof. solve_decision. Defined.
@@ -534,8 +534,8 @@ Module float_value.
       only use this helper when Clang's [APFloat] layout matches this implicit
       leading-bit encoding. In particular, x87 long double has an explicit
       integer bit and is not printed through this path. *)
-  Definition of_bits (t : t) : Z -> car t :=
-    match t with
+  Definition of_bits (ft : t) : Z -> car ft :=
+    match ft with
     | Ffloat16 => binary_float_of_bits (Reduce (fraction_bits Ffloat16)) (Reduce (exponent_bits Ffloat16)) eq_refl eq_refl eq_refl
     | Ffloat => binary_float_of_bits (Reduce (fraction_bits Ffloat)) (Reduce (exponent_bits Ffloat)) eq_refl eq_refl eq_refl
     | Fdouble => binary_float_of_bits (Reduce (fraction_bits Fdouble)) (Reduce (exponent_bits Fdouble)) eq_refl eq_refl eq_refl
@@ -543,8 +543,8 @@ Module float_value.
     | Ffloat128 => binary_float_of_bits (Reduce (fraction_bits Ffloat128)) (Reduce (exponent_bits Ffloat128)) eq_refl eq_refl eq_refl
     end.
 
-  Definition to_bits (t : t) : car t -> Z :=
-    match t with
+  Definition to_bits (ft : t) : car ft -> Z :=
+    match ft with
     | Ffloat16 => bits_of_binary_float (Reduce (fraction_bits Ffloat16)) (Reduce (exponent_bits Ffloat16))
     | Ffloat => bits_of_binary_float (Reduce (fraction_bits Ffloat)) (Reduce (exponent_bits Ffloat))
     | Fdouble => bits_of_binary_float (Reduce (fraction_bits Fdouble)) (Reduce (exponent_bits Fdouble))
@@ -552,29 +552,29 @@ Module float_value.
     | Ffloat128 => bits_of_binary_float (Reduce (fraction_bits Ffloat128)) (Reduce (exponent_bits Ffloat128))
     end.
 
-  Definition zero (t : t) : car t :=
+  Definition zero (ft : t) : car ft :=
     B754_zero _ _ false.
 
-  Definition signed_zero (t : t) : bool -> car t :=
+  Definition signed_zero (ft : t) : bool -> car ft :=
     B754_zero _ _.
 
-  Definition is_zero [t : t] (v : car t) : bool :=
+  Definition is_zero [ft : t] (v : car ft) : bool :=
     match v with
     | B754_zero _ _ _ => true
     | _ => false
     end.
 
-  Definition is_true {t : t} (v : car t) : bool :=
+  Definition is_true {ft : t} (v : car ft) : bool :=
     negb (is_zero v).
 
-  Lemma is_zero_zero (t : t) : is_zero (zero t) = true.
-  Proof. by destruct t. Qed.
+  Lemma is_zero_zero (ft : t) : is_zero (zero ft) = true.
+  Proof. by destruct ft. Qed.
 
-  Lemma is_true_zero (t : t) : is_true (zero t) = false.
-  Proof. by destruct t. Qed.
+  Lemma is_true_zero (ft : t) : is_true (zero ft) = false.
+  Proof. by destruct ft. Qed.
 
-  Definition default_nan (t : t) : { nan : car t | is_nan _ _ nan = true } :=
-    match t return { nan : car t | is_nan _ _ nan = true } with
+  Definition default_nan (ft : t) : { nan : car ft | is_nan _ _ nan = true } :=
+    match ft return { nan : car ft | is_nan _ _ nan = true } with
     | Ffloat16 => exist _ (@B754_nan 11 16 false xH eq_refl) eq_refl
     | Ffloat => exist _ (@B754_nan 24 128 false xH eq_refl) eq_refl
     | Fdouble => exist _ (@B754_nan 53 1024 false xH eq_refl) eq_refl
@@ -582,25 +582,25 @@ Module float_value.
     | Ffloat128 => exist _ (@B754_nan 113 16384 false xH eq_refl) eq_refl
     end.
 
-  Definition unop_nan [t : t] (v : car t) : { nan : car t | is_nan _ _ nan = true } :=
+  Definition unop_nan [ft : t] (v : car ft) : { nan : car ft | is_nan _ _ nan = true } :=
     match v with
     | B754_nan _ _ s pl Hpl => exist _ (B754_nan _ _ s pl Hpl) eq_refl
-    | _ => default_nan t
+    | _ => default_nan ft
     end.
 
-  Definition binop_nan [t : t] (v1 v2 : car t) : { nan : car t | is_nan _ _ nan = true } :=
+  Definition binop_nan [ft : t] (v1 v2 : car ft) : { nan : car ft | is_nan _ _ nan = true } :=
     match v1, v2 with
     | B754_nan _ _ s pl Hpl, _ => exist _ (B754_nan _ _ s pl Hpl) eq_refl
     | _, B754_nan _ _ s pl Hpl => exist _ (B754_nan _ _ s pl Hpl) eq_refl
-    | _, _ => default_nan t
+    | _, _ => default_nan ft
     end.
 
 
-  Definition opp (t : t) (v : car t) : car t :=
-    Bopp _ _ (@unop_nan t) v.
+  Definition opp (ft : t) (v : car ft) : car ft :=
+    Bopp _ _ (@unop_nan ft) v.
 
-  Definition normalize_with_mode (m : BinarySingleNaN.mode) (t : t) (z e : Z) (signed_zero : bool) : car t :=
-    match t return car t with
+  Definition normalize_with_mode (m : BinarySingleNaN.mode) (ft : t) (z e : Z) (signed_zero : bool) : car ft :=
+    match ft return car ft with
     | Ffloat16 => binary_normalize _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) m z e signed_zero
     | Ffloat => binary_normalize _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) m z e signed_zero
     | Fdouble => binary_normalize _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) m z e signed_zero
@@ -608,16 +608,16 @@ Module float_value.
     | Ffloat128 => binary_normalize _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) m z e signed_zero
     end.
 
-  Definition normalize (t : t) (z e : Z) (signed_zero : bool) : car t :=
-    normalize_with_mode BinarySingleNaN.mode_NE t z e signed_zero.
+  Definition normalize (ft : t) (z e : Z) (signed_zero : bool) : car ft :=
+    normalize_with_mode BinarySingleNaN.mode_NE ft z e signed_zero.
 
-  Definition of_int_with_mode (m : BinarySingleNaN.mode) (t : t) (z : Z) : car t :=
-    normalize_with_mode m t z 0 false.
+  Definition of_int_with_mode (m : BinarySingleNaN.mode) (ft : t) (z : Z) : car ft :=
+    normalize_with_mode m ft z 0 false.
 
-  Definition of_int (t : t) (z : Z) : car t :=
-    of_int_with_mode BinarySingleNaN.mode_NE t z.
+  Definition of_int (ft : t) (z : Z) : car ft :=
+    of_int_with_mode BinarySingleNaN.mode_NE ft z.
 
-  Definition to_int (t : t) (v : car t) : option Z :=
+  Definition to_int (ft : t) (v : car ft) : option Z :=
     match v with
     | B754_zero _ _ _ => Some 0%Z
     | B754_finite _ _ s m e _ =>
@@ -641,8 +641,8 @@ Module float_value.
   Definition cast (from to : t) : car from -> option (car to) :=
     cast_with_mode BinarySingleNaN.mode_NE from to.
 
-  Definition add_with_mode (m : BinarySingleNaN.mode) (t : t) : car t -> car t -> car t :=
-    match t return car t -> car t -> car t with
+  Definition add_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
+    match ft return car ft -> car ft -> car ft with
     | Ffloat16 => Bplus _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
     | Ffloat => Bplus _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
     | Fdouble => Bplus _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
@@ -650,8 +650,8 @@ Module float_value.
     | Ffloat128 => Bplus _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
     end.
 
-  Definition sub_with_mode (m : BinarySingleNaN.mode) (t : t) : car t -> car t -> car t :=
-    match t return car t -> car t -> car t with
+  Definition sub_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
+    match ft return car ft -> car ft -> car ft with
     | Ffloat16 => Bminus _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
     | Ffloat => Bminus _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
     | Fdouble => Bminus _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
@@ -659,8 +659,8 @@ Module float_value.
     | Ffloat128 => Bminus _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
     end.
 
-  Definition mul_with_mode (m : BinarySingleNaN.mode) (t : t) : car t -> car t -> car t :=
-    match t return car t -> car t -> car t with
+  Definition mul_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
+    match ft return car ft -> car ft -> car ft with
     | Ffloat16 => Bmult _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
     | Ffloat => Bmult _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
     | Fdouble => Bmult _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
@@ -668,8 +668,8 @@ Module float_value.
     | Ffloat128 => Bmult _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
     end.
 
-  Definition div_with_mode (m : BinarySingleNaN.mode) (t : t) : car t -> car t -> car t :=
-    match t return car t -> car t -> car t with
+  Definition div_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
+    match ft return car ft -> car ft -> car ft with
     | Ffloat16 => Bdiv _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
     | Ffloat => Bdiv _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
     | Fdouble => Bdiv _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
@@ -680,36 +680,36 @@ Module float_value.
   (** We fix the rounding mode, we will not support this changing a runtime for the time
       being because that would introduce differences between compile time and runtime evaluation.
    *)
-  Definition add (t : t) : car t -> car t -> car t := add_with_mode BinarySingleNaN.mode_NE t.
-  Definition sub (t : t) : car t -> car t -> car t := sub_with_mode BinarySingleNaN.mode_NE t.
-  Definition mul (t : t) : car t -> car t -> car t := mul_with_mode BinarySingleNaN.mode_NE t.
-  Definition div (t : t) : car t -> car t -> car t := div_with_mode BinarySingleNaN.mode_NE t.
+  Definition add (ft : t) : car ft -> car ft -> car ft := add_with_mode BinarySingleNaN.mode_NE ft.
+  Definition sub (ft : t) : car ft -> car ft -> car ft := sub_with_mode BinarySingleNaN.mode_NE ft.
+  Definition mul (ft : t) : car ft -> car ft -> car ft := mul_with_mode BinarySingleNaN.mode_NE ft.
+  Definition div (ft : t) : car ft -> car ft -> car ft := div_with_mode BinarySingleNaN.mode_NE ft.
 
-  Definition value_compare (t : t) : car t -> car t -> option comparison :=
+  Definition value_compare (ft : t) : car ft -> car ft -> option comparison :=
     Bcompare _ _.
 
   Lemma value_compare_antisym ft (x y : car ft) :
     value_compare ft y x = CompOpp <$> value_compare ft x y.
   Proof. apply Bcompare_swap. Qed.
 
-  Definition eqb (t : t) (v1 v2 : car t) : bool :=
-    bool_decide (value_compare t v1 v2 = Some Eq).
+  Definition eqb (ft : t) (v1 v2 : car ft) : bool :=
+    bool_decide (value_compare ft v1 v2 = Some Eq).
 
-  Definition neqb (t : t) (v1 v2 : car t) : bool :=
-    negb (eqb t v1 v2).
+  Definition neqb (ft : t) (v1 v2 : car ft) : bool :=
+    negb (eqb ft v1 v2).
 
-  Definition ltb (t : t) (v1 v2 : car t) : bool :=
-    bool_decide (value_compare t v1 v2 = Some Lt).
+  Definition ltb (ft : t) (v1 v2 : car ft) : bool :=
+    bool_decide (value_compare ft v1 v2 = Some Lt).
 
-  Definition leb (t : t) (v1 v2 : car t) : bool :=
-    let cmp := value_compare t v1 v2 in
+  Definition leb (ft : t) (v1 v2 : car ft) : bool :=
+    let cmp := value_compare ft v1 v2 in
     bool_decide (cmp = Some Lt \/ cmp = Some Eq).
 
-  Definition gtb (t : t) (v1 v2 : car t) : bool :=
-    ltb t v2 v1.
+  Definition gtb (ft : t) (v1 v2 : car ft) : bool :=
+    ltb ft v2 v1.
 
-  Definition geb (t : t) (v1 v2 : car t) : bool :=
-    leb t v2 v1.
+  Definition geb (ft : t) (v1 v2 : car ft) : bool :=
+    leb ft v2 v1.
 
   Lemma of_to_bits ft (f : car ft) : of_bits ft (to_bits ft f) = f.
   Proof.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/preliminary.v
@@ -543,7 +543,7 @@ Module float_value.
     | Ffloat128 => binary_float_of_bits (Reduce (fraction_bits Ffloat128)) (Reduce (exponent_bits Ffloat128)) eq_refl eq_refl eq_refl
     end.
 
-  Definition to_bits (ft : t) : car ft -> Z :=
+  Definition to_bits {ft : t} : car ft -> Z :=
     match ft with
     | Ffloat16 => bits_of_binary_float (Reduce (fraction_bits Ffloat16)) (Reduce (exponent_bits Ffloat16))
     | Ffloat => bits_of_binary_float (Reduce (fraction_bits Ffloat)) (Reduce (exponent_bits Ffloat))
@@ -558,7 +558,7 @@ Module float_value.
   Definition signed_zero (ft : t) : bool -> car ft :=
     B754_zero _ _.
 
-  Definition is_zero [ft : t] (v : car ft) : bool :=
+  Definition is_zero {ft : t} (v : car ft) : bool :=
     match v with
     | B754_zero _ _ _ => true
     | _ => false
@@ -582,13 +582,13 @@ Module float_value.
     | Ffloat128 => exist _ (@B754_nan 113 16384 false xH eq_refl) eq_refl
     end.
 
-  Definition unop_nan [ft : t] (v : car ft) : { nan : car ft | is_nan _ _ nan = true } :=
+  Definition unop_nan {ft : t} (v : car ft) : { nan : car ft | is_nan _ _ nan = true } :=
     match v with
     | B754_nan _ _ s pl Hpl => exist _ (B754_nan _ _ s pl Hpl) eq_refl
     | _ => default_nan ft
     end.
 
-  Definition binop_nan [ft : t] (v1 v2 : car ft) : { nan : car ft | is_nan _ _ nan = true } :=
+  Definition binop_nan {ft : t} (v1 v2 : car ft) : { nan : car ft | is_nan _ _ nan = true } :=
     match v1, v2 with
     | B754_nan _ _ s pl Hpl, _ => exist _ (B754_nan _ _ s pl Hpl) eq_refl
     | _, B754_nan _ _ s pl Hpl => exist _ (B754_nan _ _ s pl Hpl) eq_refl
@@ -596,17 +596,11 @@ Module float_value.
     end.
 
 
-  Definition opp (ft : t) (v : car ft) : car ft :=
-    Bopp _ _ (@unop_nan ft) v.
+  Definition opp {ft : t} (v : car ft) : car ft :=
+    Bopp _ _ unop_nan v.
 
   Definition normalize_with_mode (m : BinarySingleNaN.mode) (ft : t) (z e : Z) (signed_zero : bool) : car ft :=
-    match ft return car ft with
-    | Ffloat16 => binary_normalize _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) m z e signed_zero
-    | Ffloat => binary_normalize _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) m z e signed_zero
-    | Fdouble => binary_normalize _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) m z e signed_zero
-    | Flongdouble => binary_normalize _ _ (mw_gt_0 Flongdouble) (mw_lt_ew Flongdouble) m z e signed_zero
-    | Ffloat128 => binary_normalize _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) m z e signed_zero
-    end.
+    binary_normalize _ _ (mw_gt_0 ft) (mw_lt_ew ft) m z e signed_zero.
 
   Definition normalize (ft : t) (z e : Z) (signed_zero : bool) : car ft :=
     normalize_with_mode BinarySingleNaN.mode_NE ft z e signed_zero.
@@ -617,7 +611,7 @@ Module float_value.
   Definition of_int (ft : t) (z : Z) : car ft :=
     of_int_with_mode BinarySingleNaN.mode_NE ft z.
 
-  Definition to_int (ft : t) (v : car ft) : option Z :=
+  Definition to_int {ft : t} (v : car ft) : option Z :=
     match v with
     | B754_zero _ _ _ => Some 0%Z
     | B754_finite _ _ s m e _ =>
@@ -641,77 +635,53 @@ Module float_value.
   Definition cast (from to : t) : car from -> option (car to) :=
     cast_with_mode BinarySingleNaN.mode_NE from to.
 
-  Definition add_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
-    match ft return car ft -> car ft -> car ft with
-    | Ffloat16 => Bplus _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
-    | Ffloat => Bplus _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
-    | Fdouble => Bplus _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
-    | Flongdouble => Bplus _ _ (mw_gt_0 Flongdouble) (mw_lt_ew Flongdouble) (@binop_nan Flongdouble) m
-    | Ffloat128 => Bplus _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
-    end.
+  Definition add_with_mode (m : BinarySingleNaN.mode) {ft : t} : car ft -> car ft -> car ft :=
+    Bplus _ _ (mw_gt_0 ft) (mw_lt_ew ft) binop_nan m.
 
-  Definition sub_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
-    match ft return car ft -> car ft -> car ft with
-    | Ffloat16 => Bminus _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
-    | Ffloat => Bminus _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
-    | Fdouble => Bminus _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
-    | Flongdouble => Bminus _ _ (mw_gt_0 Flongdouble) (mw_lt_ew Flongdouble) (@binop_nan Flongdouble) m
-    | Ffloat128 => Bminus _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
-    end.
+  Definition sub_with_mode (m : BinarySingleNaN.mode) {ft : t} : car ft -> car ft -> car ft :=
+    Bminus _ _ (mw_gt_0 ft) (mw_lt_ew ft) binop_nan m.
 
-  Definition mul_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
-    match ft return car ft -> car ft -> car ft with
-    | Ffloat16 => Bmult _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
-    | Ffloat => Bmult _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
-    | Fdouble => Bmult _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
-    | Flongdouble => Bmult _ _ (mw_gt_0 Flongdouble) (mw_lt_ew Flongdouble) (@binop_nan Flongdouble) m
-    | Ffloat128 => Bmult _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
-    end.
+  Definition mul_with_mode (m : BinarySingleNaN.mode) {ft : t} : car ft -> car ft -> car ft :=
+    Bmult _ _ (mw_gt_0 ft) (mw_lt_ew ft) binop_nan m.
 
-  Definition div_with_mode (m : BinarySingleNaN.mode) (ft : t) : car ft -> car ft -> car ft :=
-    match ft return car ft -> car ft -> car ft with
-    | Ffloat16 => Bdiv _ _ (mw_gt_0 Ffloat16) (mw_lt_ew Ffloat16) (@binop_nan Ffloat16) m
-    | Ffloat => Bdiv _ _ (mw_gt_0 Ffloat) (mw_lt_ew Ffloat) (@binop_nan Ffloat) m
-    | Fdouble => Bdiv _ _ (mw_gt_0 Fdouble) (mw_lt_ew Fdouble) (@binop_nan Fdouble) m
-    | Flongdouble => Bdiv _ _ (mw_gt_0 Flongdouble) (mw_lt_ew Flongdouble) (@binop_nan Flongdouble) m
-    | Ffloat128 => Bdiv _ _ (mw_gt_0 Ffloat128) (mw_lt_ew Ffloat128) (@binop_nan Ffloat128) m
-    end.
+  Definition div_with_mode (m : BinarySingleNaN.mode) {ft : t} : car ft -> car ft -> car ft :=
+    Bdiv _ _ (mw_gt_0 ft) (mw_lt_ew ft) binop_nan m.
 
   (** We fix the rounding mode, we will not support this changing a runtime for the time
       being because that would introduce differences between compile time and runtime evaluation.
    *)
-  Definition add (ft : t) : car ft -> car ft -> car ft := add_with_mode BinarySingleNaN.mode_NE ft.
-  Definition sub (ft : t) : car ft -> car ft -> car ft := sub_with_mode BinarySingleNaN.mode_NE ft.
-  Definition mul (ft : t) : car ft -> car ft -> car ft := mul_with_mode BinarySingleNaN.mode_NE ft.
-  Definition div (ft : t) : car ft -> car ft -> car ft := div_with_mode BinarySingleNaN.mode_NE ft.
+  Definition add {ft : t} : car ft -> car ft -> car ft := add_with_mode BinarySingleNaN.mode_NE.
+  Definition sub {ft : t} : car ft -> car ft -> car ft := sub_with_mode BinarySingleNaN.mode_NE.
+  Definition mul {ft : t} : car ft -> car ft -> car ft := mul_with_mode BinarySingleNaN.mode_NE.
+  Definition div {ft : t} : car ft -> car ft -> car ft := div_with_mode BinarySingleNaN.mode_NE.
 
-  Definition value_compare (ft : t) : car ft -> car ft -> option comparison :=
+  Definition value_compare {ft : t} : car ft -> car ft -> option comparison :=
     Bcompare _ _.
 
-  Lemma value_compare_antisym ft (x y : car ft) :
-    value_compare ft y x = CompOpp <$> value_compare ft x y.
+  Lemma value_compare_antisym {ft : t} (x y : car ft) :
+    value_compare y x = CompOpp <$> value_compare x y.
   Proof. apply Bcompare_swap. Qed.
 
-  Definition eqb (ft : t) (v1 v2 : car ft) : bool :=
-    bool_decide (value_compare ft v1 v2 = Some Eq).
+  Definition eqb {ft : t} (v1 v2 : car ft) : bool :=
+    bool_decide (value_compare v1 v2 = Some Eq).
 
-  Definition neqb (ft : t) (v1 v2 : car ft) : bool :=
-    negb (eqb ft v1 v2).
+  Definition neqb {ft : t} (v1 v2 : car ft) : bool :=
+    negb (eqb v1 v2).
 
-  Definition ltb (ft : t) (v1 v2 : car ft) : bool :=
-    bool_decide (value_compare ft v1 v2 = Some Lt).
+  Definition ltb {ft : t} (v1 v2 : car ft) : bool :=
+    bool_decide (value_compare v1 v2 = Some Lt).
 
-  Definition leb (ft : t) (v1 v2 : car ft) : bool :=
-    let cmp := value_compare ft v1 v2 in
+  Definition leb {ft : t} (v1 v2 : car ft) : bool :=
+    let cmp := value_compare v1 v2 in
     bool_decide (cmp = Some Lt \/ cmp = Some Eq).
 
-  Definition gtb (ft : t) (v1 v2 : car ft) : bool :=
-    ltb ft v2 v1.
+  Definition gtb {ft : t} (v1 v2 : car ft) : bool :=
+    ltb v2 v1.
 
-  Definition geb (ft : t) (v1 v2 : car ft) : bool :=
-    leb ft v2 v1.
+  Definition geb {ft : t} (v1 v2 : car ft) : bool :=
+    leb v2 v1.
 
-  Lemma of_to_bits ft (f : car ft) : of_bits ft (to_bits ft f) = f.
+  Lemma of_to_bits {ft : t} (f : car ft) : of_bits ft (to_bits f) = f.
   Proof.
     destruct ft; simpl in *.
     - exact (binary_float_of_bits_of_binary_float 10 5 (refl_equal _) (refl_equal _) (refl_equal _) f).
@@ -721,48 +691,48 @@ Module float_value.
     - exact (binary_float_of_bits_of_binary_float 112 15 (refl_equal _) (refl_equal _) (refl_equal _) f).
   Qed.
 
-  #[global] Instance of_to_bits_cancel ft : Cancel (=) (of_bits ft) (to_bits ft) :=
-    of_to_bits ft.
+  #[global] Instance of_to_bits_cancel ft : Cancel (=) (of_bits ft) (@to_bits ft) :=
+    @of_to_bits ft.
 
-  Lemma to_bits_range ft (f : car ft) :
-    (0 <= to_bits ft f < 2 ^ float_type.bit_width ft)%Z.
+  Lemma to_bits_range {ft : t} (f : car ft) :
+    (0 <= to_bits f < 2 ^ float_type.bit_width ft)%Z.
   Proof.
     destruct ft; simpl in *; apply bits_of_binary_float_range; lia.
   Qed.
 
   Lemma to_of_bits ft z :
     (0 <= z < 2 ^ float_type.bit_width ft)%Z ->
-    to_bits ft (of_bits ft z) = z.
+    to_bits (of_bits ft z) = z.
   Proof.
     destruct ft; simpl; intros Hz; exact: bits_of_binary_float_of_bits.
   Qed.
 
   Lemma to_of_bits_Ffloat16 z :
-    (0 <= z < 2 ^ 16)%Z -> to_bits Ffloat16 (of_bits Ffloat16 z) = z.
+    (0 <= z < 2 ^ 16)%Z -> to_bits (of_bits Ffloat16 z) = z.
   Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
 
   Lemma to_of_bits_Ffloat z :
-    (0 <= z < 2 ^ 32)%Z -> to_bits Ffloat (of_bits Ffloat z) = z.
+    (0 <= z < 2 ^ 32)%Z -> to_bits (of_bits Ffloat z) = z.
   Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
 
   Lemma to_of_bits_Fdouble z :
-    (0 <= z < 2 ^ 64)%Z -> to_bits Fdouble (of_bits Fdouble z) = z.
+    (0 <= z < 2 ^ 64)%Z -> to_bits (of_bits Fdouble z) = z.
   Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
 
   Lemma to_of_bits_Ffloat128 z :
-    (0 <= z < 2 ^ 128)%Z -> to_bits Ffloat128 (of_bits Ffloat128 z) = z.
+    (0 <= z < 2 ^ 128)%Z -> to_bits (of_bits Ffloat128 z) = z.
   Proof. intros Hz. apply to_of_bits. exact Hz. Qed.
 
-  #[global] Instance to_bits_inj ft : Inj (=) (=) (to_bits ft) := cancel_inj.
+  #[global] Instance to_bits_inj ft : Inj (=) (=) (@to_bits ft) := cancel_inj.
 
-  Lemma value_compare_zero_zero ft (x y : car ft) :
-    is_zero x = true -> is_zero y = true -> value_compare ft x y = Some Eq.
+  Lemma value_compare_zero_zero {ft : t} (x y : car ft) :
+    is_zero x = true -> is_zero y = true -> value_compare x y = Some Eq.
   Proof.
     destruct ft; destruct x; destruct y; cbn; congruence.
   Qed.
 
-  Lemma value_compare_eq_or_zeros ft (x y : car ft) :
-    value_compare ft x y = Some Eq -> x = y ∨ is_zero x = true ∧ is_zero y = true.
+  Lemma value_compare_eq_or_zeros {ft : t} (x y : car ft) :
+    value_compare x y = Some Eq -> x = y ∨ is_zero x = true ∧ is_zero y = true.
   Proof.
     destruct ft; destruct x as [sx|sx|sx px Hpx|sx mx ex Hx];
       destruct y as [sy|sy|sy py Hpy|sy my ey Hy]; cbn in *; try congruence.
@@ -808,33 +778,33 @@ Module float_value.
       left; f_equal; apply: proof_irrel.
   Qed.
 
-  Lemma value_compare_eq_nonzero ft (x y : car ft) :
-    value_compare ft x y = Some Eq ->
+  Lemma value_compare_eq_nonzero {ft : t} (x y : car ft) :
+    value_compare x y = Some Eq ->
     is_zero x = false -> is_zero y = false -> x = y.
   Proof.
     move=> /value_compare_eq_or_zeros [//|[Hx _]] Hnz _.
     by rewrite Hx in Hnz.
   Qed.
 
-  Lemma value_compare_eq_B2R ft (x y : car ft) :
-    value_compare ft x y = Some Eq -> B2R _ _ x = B2R _ _ y.
+  Lemma value_compare_eq_B2R {ft : t} (x y : car ft) :
+    value_compare x y = Some Eq -> B2R _ _ x = B2R _ _ y.
   Proof.
     move=> /value_compare_eq_or_zeros [->|[Hx Hy]]; [done|].
     destruct ft; destruct x; destruct y; cbn in *; congruence.
   Qed.
 
-  Lemma value_compare_eq_sym ft (x y : car ft) :
-    value_compare ft x y = Some Eq -> value_compare ft y x = Some Eq.
+  Lemma value_compare_eq_sym {ft : t} (x y : car ft) :
+    value_compare x y = Some Eq -> value_compare y x = Some Eq.
   Proof. by move=> H; rewrite value_compare_antisym H. Qed.
 
-  Lemma value_compare_eq_trans ft (x y z : car ft) :
-    value_compare ft x y = Some Eq ->
-    value_compare ft y z = Some Eq ->
-    value_compare ft x z = Some Eq.
+  Lemma value_compare_eq_trans {ft : t} (x y z : car ft) :
+    value_compare x y = Some Eq ->
+    value_compare y z = Some Eq ->
+    value_compare x z = Some Eq.
   Proof.
     intros Hxy Hyz.
-    destruct (value_compare_eq_or_zeros _ _ _ Hxy) as [->|[Hx Hy]]; [done|].
-    destruct (value_compare_eq_or_zeros _ _ _ Hyz) as [<-|[_ Hz]]; [done|].
+    destruct (value_compare_eq_or_zeros _ _ Hxy) as [->|[Hx Hy]]; [done|].
+    destruct (value_compare_eq_or_zeros _ _ Hyz) as [<-|[_ Hz]]; [done|].
     by apply value_compare_zero_zero.
   Qed.
 

--- a/rocq-skylabs-cpp2v/tests/floating_literals.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/floating_literals.t/test.v
@@ -26,7 +26,7 @@ Definition check_return (nm : ident) (ft : float_type.t) : bool :=
 Definition check_return_bits (nm : ident) (ft : float_type.t) (bits : Z) : bool :=
   match return_expr nm with
   | Some (Efloat ft' f) =>
-      bool_decide (ft = ft') && bool_decide (float_value.to_bits ft' f = bits)
+      bool_decide (ft = ft') && bool_decide (float_value.to_bits f = bits)
   | _ => false
   end.
 


### PR DESCRIPTION
While working on https://github.com/SkyLabsAI/BRiCk/issues/148, I was missing a proof that `value_compare ft x y = Some Eq -> x = y` in the spaceship work. Turns out it's false because of signed zeros.

I also cleaned up a few issues.

Reviewable by commit.