### PR TITLE
Support for initializer-statements on [if] and [switch]

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/logic/stmt.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/stmt.v
@@ -413,17 +413,26 @@ Module Type Stmt.
 
     (** * <<if>> *)
 
-    Axiom wp_if : forall ρ e thn els Q,
-        |> Unfold WPE.wp_test (wp_test tu ρ e (fun c free =>
-               interp free $
-               if c
-               then wp ρ thn Q
-               else wp ρ els Q))
-      |-- wp ρ (Sif None e thn els) Q.
+    Definition pre_stmt (init : option Stmt) (decl : option VarDecl) : option (list Stmt) :=
+      match init , decl with
+      | None , None      => None
+      | Some s , None    => Some [s]
+      | None , Some vd   => Some [Sdecl [vd]]
+      | Some s , Some vd => Some [s; Sdecl [vd]]
+      end.
 
-    Axiom wp_if_decl : forall ρ d e thn els Q,
-        wp ρ (Sseq (Sdecl (d :: nil) :: Sif None e thn els :: nil)) Q
-        |-- wp ρ (Sif (Some d) e thn els) Q.
+    Axiom wp_if : forall ρ init decl e thn els Q,
+        match pre_stmt init decl with
+        | None =>
+        |> letI* c , free := Unfold WPE.wp_test (wp_test tu ρ e) in
+           interp free $
+             if c
+             then wp ρ thn Q
+             else wp ρ els Q
+        | Some ss =>
+            wp ρ (Sseq (ss ++ [Sif None None e thn els])) Q
+        end
+      |-- wp ρ (Sif init decl e thn els) Q.
 
     (* The loops are phrased using 1-step unfoldings and invariant rules are
        proved using Löb induction.
@@ -449,7 +458,7 @@ Module Type Stmt.
     (** * <<while>> *)
 
     Definition while_unroll ρ decl test body :=
-      wp ρ (Sif decl test body Sbreak).
+      wp ρ (Sif None decl test body Sbreak).
 
     Axiom wp_while_unroll : forall ρ decl test body Q,
             while_unroll ρ decl test body (Kloop (|> wp ρ (Swhile decl test body) Q) Q)
@@ -502,7 +511,7 @@ Module Type Stmt.
       in
       match test with
       | None => wp ρ body
-      | Some test => wp ρ (Sif None test body Sbreak)
+      | Some test => wp ρ (Sif None None test body Sbreak)
       end Kinc.
 
     Axiom wp_for_unroll : forall ρ test incr body Q,
@@ -645,13 +654,13 @@ Module Type Stmt.
       match s with
       | Sseq ls => forallb no_case ls
       | Sdecl _ => true
-      | Sif _ _ a b
+      | Sif _ _ _ a b
       | Sif_consteval a b => no_case a && no_case b
       | Swhile _ _ s => no_case s
       | Sfor _ _ _ s => no_case s
       | Sdo s _ => no_case s
       | Sattr _ s => no_case s
-      | Sswitch _ _ _ => true
+      | Sswitch _ _ _ _ => true
       | Scase _
       | Sdefault => false
       | Sbreak
@@ -748,22 +757,24 @@ Module Type Stmt.
          rewrite !monPred_at_fupd /=.
     Qed.
 
-    Axiom wp_switch_decl : forall ρ d e ls Q,
-        wp ρ (Sseq (Sdecl (d :: nil) :: Sswitch None e ls :: nil)) Q
-        |-- wp ρ (Sswitch (Some d) e ls) Q.
-
     (* An error to say that a `switch` block with [body] is not supported *)
     Record switch_block (body : list Stmt) : Prop := {}.
 
-    Axiom wp_switch : forall ρ e b Q,
-        match wp_switch_block (Some $ default_from_cases (get_cases b)) b with
-        | None => UNSUPPORTED (switch_block b)
-        | Some cases =>
-          wp_operand tu ρ e (fun v free => interp free $
-                    Exists vv : Z, [| v = Vint vv |] **
-                    [∧list] x ∈ cases, [| x.1 vv |] -* wp_block ρ x.2 (Kswitch Q))
+    Axiom wp_switch : forall ρ init decl e b Q,
+        match pre_stmt init decl with
+        | None =>
+          match wp_switch_block (Some $ default_from_cases (get_cases b)) b with
+          | None => UNSUPPORTED (switch_block b)
+          | Some cases =>
+            letI* v, free := wp_operand tu ρ e in
+            interp free $
+              Exists vv : Z, [| v = Vint vv |] **
+              [∧list] x ∈ cases, [| x.1 vv |] -* wp_block ρ x.2 (Kswitch Q)
+          end
+        | Some ss =>
+            wp ρ (Sseq (ss ++ [Sswitch None None e (Sseq b)])) Q
         end
-        |-- wp ρ (Sswitch None e (Sseq b)) Q.
+        |-- wp ρ (Sswitch init decl e (Sseq b)) Q.
 
     (* note: case and default statements are only meaningful inside of [switch].
      * this is handled by [wp_switch_block].

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -2290,12 +2290,12 @@ Module Stmt.
       match s with
       | Sseq _ => 1
       | Sdecl _ => 2
-      | Sif _ _ _ _ => 3
+      | Sif _ _ _ _ _ => 3
       | Sif_consteval _ _ => 19
       | Swhile _ _ _ => 4
       | Sfor _ _ _ _ => 5
       | Sdo _ _ => 6
-      | Sswitch _ _ _ => 7
+      | Sswitch _ _ _ _ => 7
       | Scase _ => 8
       | Sdefault => 9
       | Sbreak => 10
@@ -2312,12 +2312,12 @@ Module Stmt.
       match k with
       | 1 => list Stmt
       | 2 => list VarDecl
-      | 3 => option VarDecl * Expr * Stmt * Stmt
+      | 3 => option Stmt * option VarDecl * Expr * Stmt * Stmt
       | 19 => Stmt * Stmt
       | 4 => option VarDecl * Expr * Stmt
       | 5 => option Stmt * option Expr * option Expr * Stmt
       | 6 => Stmt * Expr
-      | 7 => option VarDecl * Expr * Stmt
+      | 7 => option Stmt * option VarDecl * Expr * Stmt
       | 8 => SwitchBranch
       | 9 => unit
       | 10 => unit
@@ -2334,12 +2334,12 @@ Module Stmt.
       match s with
       | Sseq a => a
       | Sdecl a => a
-      | Sif a b c d => (a,b,c,d)
+      | Sif a b c d e => (a,b,c,d,e)
       | Sif_consteval a b => (a,b)
       | Swhile a b c => (a,b,c)
       | Sfor a b c d => (a,b,c,d)
       | Sdo a b => (a,b)
-      | Sswitch a b c => (a,b,c)
+      | Sswitch a b c d => (a,b,c,d)
       | Scase a => a
       | Sdefault => tt
       | Sbreak => ()
@@ -2381,12 +2381,12 @@ Module Stmt.
       match s with
       | Sseq a => compare_ctor (Sseq a)
       | Sdecl a => compare_ctor (Sdecl a)
-      | Sif a b c d => compare_ctor (Sif a b c d)
+      | Sif a b c d e => compare_ctor (Sif a b c d e)
       | Sif_consteval a b => compare_ctor (Sif_consteval a b)
       | Swhile a b c => compare_ctor (Swhile a b c)
       | Sfor a b c d => compare_ctor (Sfor a b c d)
       | Sdo a b => compare_ctor (Sdo a b)
-      | Sswitch a b c => compare_ctor (Sswitch a b c)
+      | Sswitch a b c d => compare_ctor (Sswitch a b c d)
       | Scase a => compare_ctor (Scase a)
       | Sdefault => compare_ctor (Sdefault)
       | Sbreak => compare_ctor (Sbreak)

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -560,14 +560,17 @@ with Stmt : Set :=
 | Sseq    (_ : list Stmt)
 | Sdecl   (_ : list VarDecl)
 
-| Sif     (_ : option VarDecl) (_ : Expr) (_ _ : Stmt)
+| Sif     (init : option Stmt) (decl : option VarDecl) (test : Expr) (thn els : Stmt)
+  (* ^^ if (init; decl) { ... } else { ... }
+     the test is the expressions
+   *)
 | Sif_consteval (_ _ : Stmt)
 
 | Swhile  (_ : option VarDecl) (_ : Expr) (_ : Stmt)
 | Sfor    (_ : option Stmt) (_ : option Expr) (_ : option Expr) (_ : Stmt)
 | Sdo     (_ : Stmt) (_ : Expr)
 
-| Sswitch (_ : option VarDecl) (_ : Expr) (_ : Stmt)
+| Sswitch (_ : option Stmt) (_ : option VarDecl) (_ : Expr) (_ : Stmt)
 | Scase   (_ : SwitchBranch)
 | Sdefault
 
@@ -1020,7 +1023,8 @@ with is_dependentS (s : Stmt) : bool :=
   match s with
   | Sseq ss => List.existsb is_dependentS ss
   | Sdecl ds => List.existsb is_dependentVD ds
-  | Sif ovd e thn els =>
+  | Sif os ovd e thn els =>
+      option.existsb is_dependentS os ||
       option.existsb is_dependentVD ovd || is_dependentE e || is_dependentS thn || is_dependentS els
   | Sif_consteval thn els =>
       is_dependentS thn || is_dependentS els
@@ -1029,7 +1033,8 @@ with is_dependentS (s : Stmt) : bool :=
   | Sfor os oe1 oe2 s =>
       option.existsb is_dependentS os || option.existsb is_dependentE oe1 || option.existsb is_dependentE oe2 || is_dependentS s
   | Sdo b t => is_dependentS b || is_dependentE t
-  | Sswitch ovd e s =>
+  | Sswitch os ovd e s =>
+      option.existsb is_dependentS os ||
       option.existsb is_dependentVD ovd || is_dependentE e || is_dependentS s
   | Scase _
   | Sdefault

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
@@ -320,12 +320,12 @@ Module MTraverse.
       match s with
       | Sseq ss => Sseq <$> traverse (T:=eta list) traverseS ss
       | Sdecl ds => Sdecl <$> traverse (T:=eta list) traverseD ds
-      | Sif d e sif selse => Sif <$> traverse (T:=eta option) traverseD d <*> traverseE e <*> traverseS sif <*> traverseS selse
+      | Sif i d e sif selse => Sif <$> traverse (T:=eta option) traverseS i <*> traverse (T:=eta option) traverseD d <*> traverseE e <*> traverseS sif <*> traverseS selse
       | Sif_consteval sif selse => Sif_consteval <$> traverseS sif <*> traverseS selse
       | Swhile d e s => Swhile <$> traverse (T:=eta option) traverseD d <*> traverseE e <*> traverseS s
       | Sfor i g c s => Sfor <$> traverse (T:=eta option) traverseS i <*> traverse (T:=eta option) traverseE g <*> traverse (T:=eta option) traverseE c <*> traverseS s
       | Sdo s e => Sdo <$> traverseS s <*> traverseE e
-      | Sswitch d e s => Sswitch <$> traverse (T:=eta option) traverseD d <*> traverseE e <*> traverseS s
+      | Sswitch i d e s => Sswitch <$> traverse (T:=eta option) traverseS i <*> traverse (T:=eta option) traverseD d <*> traverseE e <*> traverseS s
       | Scase br => mret $ Scase br
       | Sdefault => mret Sdefault
       | Sbreak => mret Sbreak

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -263,13 +263,13 @@ Section with_monad.
     match s with
     | Sseq ss => lst stmt ss
     | Sdecl ds => lst var_decl ds
-    | Sif ovd e s1 s2 => opt var_decl ovd <+> expr e <+> stmt s1 <+> stmt s2
+    | Sif os ovd e s1 s2 => opt stmt os <+> opt var_decl ovd <+> expr e <+> stmt s1 <+> stmt s2
     | Sif_consteval _ _ => FAIL "if consteval"
     | Swhile ovd e s => opt var_decl ovd <+> expr e <+> stmt s
     | Sdo s e => stmt s <+> expr e
     | Sfor os oe1 oe2 s =>
         opt stmt os <+> opt expr oe1 <+> opt expr oe2 <+> stmt s
-    | Sswitch ovd e s => opt var_decl ovd <+> expr e <+> stmt s
+    | Sswitch os ovd e s => opt stmt os <+> opt var_decl ovd <+> expr e <+> stmt s
     | Scase _ => OK
     | Sdefault | Sbreak | Scontinue => OK
     | Sreturn oe => opt expr oe

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -958,23 +958,27 @@ Module decltype.
                    let* '(b,d) := check_stmt s in
                    with_bindings b $ block ss
                end) ss
-        | Sif vd tst thn els =>
+        | Sif os vd tst thn els =>
+            let* '(bs, ret) := from_option check_stmt (mret (monoid.monoid_unit, None)) os in
+            with_bindings bs $
             let* ds := from_option check_decl (mret monoid.monoid_unit) vd in
+            with_bindings ds $
             let* _ :=
-              with_bindings ds $
-                let* _ := of_expr tst >>= require_testable in
-                let* _ := check_stmt thn in
-                check_stmt els
+              let* _ := of_expr tst >>= require_testable in
+              let* _ := check_stmt thn in
+              check_stmt els
             in mret (∅, None)
         | Sif_consteval thn els =>
             let* _ := check_stmt thn in
             check_stmt els
-        | Sswitch vd tst b =>
+        | Sswitch os vd tst b =>
+            let* '(bs, ret) := from_option check_stmt (mret (monoid.monoid_unit, None)) os in
+            with_bindings bs $
             let* ds := from_option check_decl (mret monoid.monoid_unit) vd in
+            with_bindings ds $
             let _ :=
-              with_bindings ds $
-                let* _ := of_expr tst >>= require_eq Tint in (* TODO: BAD *)
-                check_stmt b
+              let* _ := of_expr tst >>= require_eq Tint in (* TODO: BAD *)
+              check_stmt b
             in mret (∅, None)
         | Swhile vd tst body =>
             let* ds := from_option check_decl (mret monoid.monoid_unit) vd in

--- a/rocq-skylabs-cpp2v/src/PrintStmt.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintStmt.cpp
@@ -183,6 +183,14 @@ public:
             }
         } else {
             guard::ctor _{print, "Sif"};
+            if (auto v = stmt->getInit()) {
+                print.some();
+                cprint.printStmt(print, v);
+                print.end_ctor();
+            } else {
+                print.none();
+            }
+            print.output() << fmt::nbsp;
             if (auto v = stmt->getConditionVariable()) {
                 print.some();
                 cprint.printLocalDecl(print, v);
@@ -254,6 +262,14 @@ public:
     void VisitSwitchStmt(const SwitchStmt *stmt, CoqPrinter &print,
                          ClangPrinter &cprint, ASTContext &) {
         print.ctor("Sswitch");
+        if (auto v = stmt->getInit()) {
+            print.some();
+            cprint.printStmt(print, v);
+            print.end_ctor();
+        } else {
+            print.none();
+        }
+        print.output() << fmt::nbsp;
         if (auto v = stmt->getConditionVariable()) {
             print.some();
             cprint.printLocalDecl(print, v);
@@ -261,8 +277,9 @@ public:
         } else {
             print.none();
         }
+        print.output() << fmt::nbsp;
         cprint.printExpr(print, stmt->getCond());
-
+        print.output() << fmt::nbsp;
         cprint.printStmt(print, stmt->getBody());
         print.end_ctor();
     }

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_if_switch_init.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_if_switch_init.t/run.t
@@ -1,0 +1,4 @@
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  rocq c -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_if_switch_init.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_if_switch_init.t/test.cpp
@@ -1,0 +1,50 @@
+int if_init_only(int x) {
+  if (int seed = x + 1; seed == 4) {
+    return seed;
+  } else {
+    return 0;
+  }
+}
+
+int if_decl_only(int x) {
+  if (int value = x + 2) {
+    return value;
+  } else {
+    return 0;
+  }
+}
+
+int if_init_and_decl(int x) {
+  if (int seed = x + 1; int value = seed + 2) {
+    return value;
+  } else {
+    return 0;
+  }
+}
+
+int switch_init_only(int x) {
+  switch (int tag = x + 1; tag) {
+  case 4:
+    return tag;
+  default:
+    return 0;
+  }
+}
+
+int switch_decl_only(int x) {
+  switch (int tag = x + 2) {
+  case 5:
+    return tag;
+  default:
+    return 0;
+  }
+}
+
+int switch_init_and_decl(int x) {
+  switch (int seed = x + 1; int tag = seed + 2) {
+  case 6:
+    return tag;
+  default:
+    return 0;
+  }
+}


### PR DESCRIPTION
This feature was added in C++98 and allows for

```
if (int x = 7; auto t = x < 5) ...
```

Closes #237