### PR TITLE
Fix support for template constexpr

### DIFF
--- a/rocq-skylabs-cpp2v/src/PrintStmt.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintStmt.cpp
@@ -144,7 +144,7 @@ public:
 
     void VisitIfStmt(const IfStmt *stmt, CoqPrinter &print,
                      ClangPrinter &cprint, ASTContext &) {
-        if (stmt->isConsteval()) {
+        if (stmt->isConsteval() || stmt->isConstexpr()) {
             guard::ctor _{print, "Sif_consteval"};
             cprint.printStmt(print, stmt->getThen());
             print.output() << fmt::nbsp;

--- a/rocq-skylabs-cpp2v/src/PrintStmt.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintStmt.cpp
@@ -145,16 +145,9 @@ public:
     void VisitIfStmt(const IfStmt *stmt, CoqPrinter &print,
                      ClangPrinter &cprint, ASTContext &) {
         if (stmt->isConsteval() || stmt->isConstexpr()) {
-            guard::ctor _{print, "Sif_consteval"};
-            cprint.printStmt(print, stmt->getThen());
-            print.output() << fmt::nbsp;
-            if (stmt->getElse()) {
-                cprint.printStmt(print, stmt->getElse());
-            } else {
-                print.output() << "Sskip";
-            }
+            print.ctor("Sif_consteval");
         } else {
-            guard::ctor _{print, "Sif"};
+            print.ctor("Sif");
             print.option(stmt->getInit(), [&](const Stmt *v) {
                 cprint.printStmt(print, v);
             });
@@ -165,14 +158,15 @@ public:
             print.space();
             cprint.printExpr(print, stmt->getCond());
             print.space();
-            cprint.printStmt(print, stmt->getThen());
-            print.space();
-            if (stmt->getElse()) {
-                cprint.printStmt(print, stmt->getElse());
-            } else {
-                print.output() << "Sskip";
-            }
         }
+        cprint.printStmt(print, stmt->getThen());
+        print.space();
+        if (stmt->getElse()) {
+            cprint.printStmt(print, stmt->getElse());
+        } else {
+            print.output() << "Sskip";
+        }
+        print.end_ctor();
     }
 
     static bool constexprEvalInt(const Expr &expr, ASTContext &ctxt,


### PR DESCRIPTION
Tests in progress. Came up in work on https://github.com/SkyLabsAI/BRiCk/issues/148.

## Symptoms on the `paolo/spaceship` worktree

Before the last two commits, 
```
dune b _build/default/fmdeps/brick-libcpp/rocq-brick-libstdcpp/proof/compare/inc_compare_cpp_templates.vo
```
fails with
```
File "./fmdeps/brick-libcpp/rocq-brick-libstdcpp/proof/compare/inc_compare_cpp_templates.v", line 2798, characters 19-84:
Error:
The term "Eunsupported "potentially dependent concept specialization" Tbool"
has type "Expr" while it is expected to have type 
"option VarDecl".
```
 and that seems due an `if constexpr` in `/usr/include/c++/12/concepts` — in our Docker container
```
      struct _Swap
      {
      private:
	template<typename _Tp, typename _Up>
	  static constexpr bool
	  _S_noexcept()
	  {
	    if constexpr (__adl_swap<_Tp, _Up>)
	      return noexcept(swap(std::declval<_Tp>(), std::declval<_Up>()));
	    else
	      return is_nothrow_move_constructible_v<remove_reference_t<_Tp>>
		   && is_nothrow_move_assignable_v<remove_reference_t<_Tp>>;
	  }
```
AST with `clang++ -Xclang -ast-dump  -std=c++20`
```
| | |   |     `-IfStmt 0x5555558aed68 <line:184:6, line:188:61> has_else constexpr
| | |   |       |-ConceptSpecializationExpr 0x5555558ae578 <line:184:20, col:39> 'bool' Concept 0x5555558a88d8 '__adl_swap'
| | |   |       | |-ImplicitConceptSpecializationDecl 0x5555558ae488 <line:170:10> col:10
| | |   |       | | |-TemplateArgument type 'type-parameter-0-0'
| | |   |       | | | `-TemplateTypeParmType 0x5555556c1770 'type-parameter-0-0' dependent depth 0 index 0
| | |   |       | | `-TemplateArgument type 'type-parameter-0-1'
| | |   |       | |   `-TemplateTypeParmType 0x5555556f5510 'type-parameter-0-1' dependent depth 0 index 1
| | |   |       | |-TemplateArgument <line:184:31> type '_Tp':'type-parameter-0-0'
| | |   |       | | `-TemplateTypeParmType 0x5555558a8f00 '_Tp' dependent depth 0 index 0
| | |   |       | |   `-TemplateTypeParm 0x5555558a8eb0 '_Tp'
| | |   |       | `-TemplateArgument <col:36> type '_Up':'type-parameter-0-1'
| | |   |       |   `-TemplateTypeParmType 0x5555558a8f90 '_Up' dependent depth 0 index 1
| | |   |       |     `-TemplateTypeParm 0x5555558a8f38 '_Up'
```