### PR TITLE
Fix bug in printing names with global name resolution operator

### DIFF
--- a/rocq-skylabs-cpp2v/src/PrintName.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintName.cpp
@@ -1238,7 +1238,8 @@ fmt::Formatter &ClangPrinter::printNestedName(CoqPrinter &print,
     }
     case NestedNameSpecifier::Kind::Namespace: {
         NamespaceAndPrefix np = spec.getAsNamespaceAndPrefix();
-        if (np.Prefix) {
+        if (np.Prefix &&
+            np.Prefix.getKind() != NestedNameSpecifier::Kind::Global) {
             guard::ctor _{print, "Nscoped"};
             printNestedName(print, np.Prefix, loc) << fmt::nbsp;
             printName(print, np.Namespace, loc, false);

--- a/rocq-skylabs-cpp2v/src/PrintName.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintName.cpp
@@ -17,6 +17,7 @@
 #include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/Basic/Version.inc>
 #include <clang/Frontend/CompilerInstance.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <optional>
 
 using namespace clang;
@@ -1229,13 +1230,14 @@ fmt::Formatter &ClangPrinter::printNestedName(CoqPrinter &print,
         print.output() << "\"NestedNameSpecifier(empty)\"";
         return print.output();
     }
+
     switch (spec.getKind()) {
     case NestedNameSpecifier::Kind::Null:
         llvm_unreachable("unexpected Null NestedNameSpecifier");
-    case NestedNameSpecifier::Kind::Global: {
-        guard::ctor _(print, "Nglobal", false);
-        break;
-    }
+    case NestedNameSpecifier::Kind::Global:
+        // global itself is un-representable, so all callers of this function
+        // guarantee this
+        llvm_unreachable("unspected Global NestedNameSpecifier");
     case NestedNameSpecifier::Kind::Namespace: {
         NamespaceAndPrefix np = spec.getAsNamespaceAndPrefix();
         if (np.Prefix &&

--- a/rocq-skylabs-cpp2v/tests/global_nested_name.t/Makefile
+++ b/rocq-skylabs-cpp2v/tests/global_nested_name.t/Makefile
@@ -1,0 +1,8 @@
+CPPFLAGS = -std=c++17
+
+Q = @
+
+all: test_cpp.v
+
+test_cpp.v: test.cpp
+	$(Q)cpp2v -v -o $@ $< --check-types -- $(CPPFLAGS)

--- a/rocq-skylabs-cpp2v/tests/global_nested_name.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/global_nested_name.t/run.t
@@ -1,0 +1,9 @@
+  $ . ../setup-project.sh
+
+Compiling the C++ code, use "make Q=" for debugging.
+  $ make 2> /dev/null
+  $ ls *.v | wc -l | sed -e 's/ //g'
+  2
+
+Compiling the generated Coq files.
+  $ dune build

--- a/rocq-skylabs-cpp2v/tests/global_nested_name.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/global_nested_name.t/test.cpp
@@ -1,0 +1,16 @@
+namespace cxx {
+template<typename T>
+T&& move(T& value);
+}
+
+void foo() {}
+
+template<typename T>
+struct Pair {
+  T first;
+
+  Pair(Pair&& pair) {
+    ::foo();
+    first = ::cxx::move(pair.first);
+  }
+};

--- a/rocq-skylabs-cpp2v/tests/global_nested_name.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/global_nested_name.t/test.v
@@ -1,0 +1,1 @@
+Require test.test_cpp.


### PR DESCRIPTION
These names are things like `::foo()` or `::cxx::foo()`.

Fix https://github.com/SkyLabsAI/BRiCk/issues/243.