### PR TITLE
enable native libstdc++ cpp2v in macos

### DIFF
--- a/rocq-skylabs-cpp2v/src/cpp2v.cpp
+++ b/rocq-skylabs-cpp2v/src/cpp2v.cpp
@@ -27,6 +27,10 @@
 #include "Trace.hpp"
 #include "Version.hpp"
 #include "llvm/Support/CommandLine.h"
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace clang;
 using namespace clang::tooling;
@@ -214,6 +218,42 @@ bool isDarwin() {
     return strcmp(name.sysname, "Darwin") == 0;
 }
 
+std::optional<std::string> getEnv(const char *name) {
+    if (const char *value = std::getenv(name)) {
+        if (*value != '\0') {
+            return std::string(value);
+        }
+    }
+    return {};
+}
+
+std::vector<std::string> splitColonSeparated(const std::string &value) {
+    std::vector<std::string> entries;
+    std::stringstream stream(value);
+    std::string entry;
+    while (std::getline(stream, entry, ':')) {
+        if (!entry.empty()) {
+            entries.push_back(entry);
+        }
+    }
+    return entries;
+}
+
+void addArg(ClangTool &Tool, const std::string &arg, const char *desc) {
+    Tool.appendArgumentsAdjuster(
+        getInsertArgumentAdjuster(std::vector<std::string>{arg},
+                                  ArgumentInsertPosition::BEGIN));
+    logging::log(logging::Level::VERBOSER) << "Using " << desc << ": " << arg
+                                           << "\n";
+}
+
+void addArgs(ClangTool &Tool, const std::vector<std::string> &args,
+             const char *desc) {
+    Tool.appendArgumentsAdjuster(
+        getInsertArgumentAdjuster(args, ArgumentInsertPosition::BEGIN));
+    logging::log(logging::Level::VERBOSER) << "Using " << desc << "\n";
+}
+
 void addOpt(ClangTool &Tool, const char *opt, std::optional<std::string> value,
             const char *desc) {
     if (value.has_value()) {
@@ -227,6 +267,29 @@ void addOpt(ClangTool &Tool, const char *opt, std::optional<std::string> value,
     } else {
         logging::log(logging::Level::VERBOSER)
             << "Could not detect " << desc << ".\n";
+    }
+}
+
+bool hasEnvToolchain() {
+    return getEnv("CPP2V_TARGET").has_value() ||
+           getEnv("CPP2V_SYSROOT").has_value() ||
+           getEnv("CPP2V_GCC_TOOLCHAIN").has_value() ||
+           getEnv("CPP2V_CXX_INCLUDE_DIRS").has_value();
+}
+
+void addEnvToolchainArgs(ClangTool &Tool) {
+    addOpt(Tool, "-resource-dir=", getEnv("CPP2V_RESOURCE_DIR"),
+           "CPP2V_RESOURCE_DIR");
+    addOpt(Tool, "--target=", getEnv("CPP2V_TARGET"), "CPP2V_TARGET");
+    addOpt(Tool, "--sysroot=", getEnv("CPP2V_SYSROOT"), "CPP2V_SYSROOT");
+    addOpt(Tool, "--gcc-toolchain=", getEnv("CPP2V_GCC_TOOLCHAIN"),
+           "CPP2V_GCC_TOOLCHAIN");
+
+    if (auto dirs = getEnv("CPP2V_CXX_INCLUDE_DIRS")) {
+        addArg(Tool, "-nostdinc++", "CPP2V_CXX_INCLUDE_DIRS");
+        for (const auto &dir : splitColonSeparated(*dirs)) {
+            addArgs(Tool, {"-isystem", dir}, "CPP2V_CXX_INCLUDE_DIRS entry");
+        }
     }
 }
 
@@ -257,7 +320,9 @@ int main(int argc, const char **argv) {
     ClangTool Tool(OptionsParser.getCompilations(),
                    OptionsParser.getSourcePathList());
 
-    if (!NoSystem.getValue()) {
+    addEnvToolchainArgs(Tool);
+
+    if (!NoSystem.getValue() && !hasEnvToolchain()) {
         addOpt(Tool, "-resource-dir=", getClangResourceDir(),
                "the system resource directory");
 


### PR DESCRIPTION
(created by codex-cli)

## Summary

Add an environment-based toolchain configuration path to `cpp2v`.

This introduces the following `CPP2V_*` variables:

- `CPP2V_RESOURCE_DIR`
- `CPP2V_TARGET`
- `CPP2V_SYSROOT`
- `CPP2V_GCC_TOOLCHAIN`
- `CPP2V_CXX_INCLUDE_DIRS`

When set, `cpp2v` translates them into the corresponding Clang frontend arguments before parsing:

- `-resource-dir=...`
- `--target=...`
- `--sysroot=...`
- `--gcc-toolchain=...`
- `-nostdinc++`
- explicit `-isystem ...` entries for the configured C++ include directories

If a target/sysroot/toolchain is configured through the environment, `cpp2v` skips the host-system default setup path. This avoids mixing host defaults, such as macOS/Darwin headers, with an explicitly configured Linux target sysroot.

## Use case

In our use case, `cpp2v` runs as a native macOS executable, but Clang's frontend needs to parse C++ sources as Linux amd64 code using GCC/libstdc++ headers.

Concretely, on Apple Silicon macOS:

- `cpp2v` itself is built against Homebrew LLVM and runs natively.
- The source being translated is intended for Linux amd64.
- A Linux amd64 sysroot provides the target headers and GCC/libstdc++ 15 headers.
- `CPP2V_TARGET=x86_64-linux-gnu` makes Clang use Linux/x86 target assumptions.
- `CPP2V_SYSROOT` and `CPP2V_GCC_TOOLCHAIN` point Clang at the target filesystem/toolchain.
- `CPP2V_CXX_INCLUDE_DIRS` forces C++ standard-library ASTs to come from Linux GCC/libstdc++ rather than macOS/Homebrew libc++.

This is also useful when `cpp2v` is invoked indirectly by generated build rules, such as generated Dune rules. Some direct callers can pass `--extra-arg-before=...` flags explicitly, and some compile flags can come from `compile_commands.json`, but generated build rules may not be convenient to rewrite after generation. Environment-based configuration gives all `cpp2v` invocations in the build one central way to select the target, sysroot, GCC toolchain, Clang resource directory, and C++ standard-library include paths.

## Testing

- `dune build @fmdeps/BRiCk/rocq-skylabs-cpp2v/cpp2v`
