### PR TITLE
fix(cpp2v): switch cornercase, non-compound statement body

### DIFF
--- a/rocq-skylabs-cpp2v/src/PrintStmt.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintStmt.cpp
@@ -238,7 +238,30 @@ public:
         print.output() << fmt::nbsp;
         cprint.printExpr(print, stmt->getCond());
         print.output() << fmt::nbsp;
-        cprint.printStmt(print, stmt->getBody());
+        /*
+         * The body of a `switch` need not be a compound statement, but
+         * `Scase`/`Sdefault` are markers *within* the list of an `Sseq`, and
+         * `wp_switch` only looks for them there. Print the block that the
+         * substatement already denotes: it "implicitly defines a block scope",
+         * and when it is "a single statement and not a compound-statement, it
+         * is as if it was rewritten to be a compound-statement containing the
+         * original substatement" ([stmt.select]/2, [stmt.select.general]/2 in
+         * later revisions). This is the shape gtest's
+         * `GTEST_AMBIGUOUS_ELSE_BLOCKER_` (`switch (0) case 0: default:`)
+         * expands to, and it yields exactly the AST of the braced spelling.
+         *
+         * The guard matters: wrapping a body that is already a compound
+         * statement would bury its labels one `Sseq` deeper, where
+         * `get_cases` cannot see them.
+         */
+        if (isa<CompoundStmt>(stmt->getBody())) {
+            cprint.printStmt(print, stmt->getBody());
+        } else {
+            guard::ctor _{print, "Sseq"};
+            guard::list __{print};
+            cprint.printStmt(print, stmt->getBody());
+            print.cons();
+        }
         print.end_ctor();
     }
 

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_switch_no_compound.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_switch_no_compound.t/run.t
@@ -1,0 +1,19 @@
+The body of a switch need not be a compound statement. This is not just a
+corner case: googletest's GTEST_AMBIGUOUS_ELSE_BLOCKER_ expands to
+"switch (0) case 0: default:" and every ASSERT_ and EXPECT_ macro wraps its
+body in it, so the form below is what those macros expand to.
+
+  $ . ../../setup-cpp2v.sh
+  $ check_cpp2v test.cpp
+  cpp2v -v -check-types -o test_17_cpp.v test.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  rocq c -w -notation-overridden -w -notation-incompatible-prefix test_17_cpp.v
+
+Such a substatement implicitly defines a block scope, and is as if rewritten as
+a compound-statement containing it ([stmt.select]/2), so the AST must be exactly
+the one produced for the explicitly braced spelling: the labels land in the list
+of the same [Sseq], which is where [wp_switch] looks for them.
+
+  $ check_cpp2v test_braced.cpp
+  cpp2v -v -check-types -o test_braced_17_cpp.v test_braced.cpp -- -std=c++17 2>&1 | sed 's/^ *[0-9]* | //'
+  rocq c -w -notation-overridden -w -notation-incompatible-prefix test_braced_17_cpp.v
+  $ diff test_17_cpp.v test_braced_17_cpp.v

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_switch_no_compound.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_switch_no_compound.t/test.cpp
@@ -1,0 +1,2 @@
+void g();
+void f(int x) { switch (0) case 0: default: if (x) ; else g(); }

--- a/rocq-skylabs-cpp2v/tests/cpp2v/test_switch_no_compound.t/test_braced.cpp
+++ b/rocq-skylabs-cpp2v/tests/cpp2v/test_switch_no_compound.t/test_braced.cpp
@@ -1,0 +1,2 @@
+void g();
+void f(int x) { switch (0) { case 0: default: if (x) ; else g(); } }


### PR DESCRIPTION
GTest macros expand to a switch statement of the form `switch (0) case 0: ...` (i.e. the switch body is a `statement` instead of a `compound-statement`), but this previously yielded ill-typed ASTs in Rocq.