### PR TITLE
feat: `std::initializer_list`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,32 +15,10 @@ implicit construction of a `std::initializer_list<E>` from a braced-init-list
 (<http://eel.is/c++draft/dcl.init.list#5>).
 - New `Expr` constructor `Einitlist_std (backing : Expr) (t : type)`. Downstream
   exhaustive matches over `Expr` need a new case.
-- New **abstract** representation predicate `initializer_listR ety q arrayp n`
-  in `lang/cpp/logic/expr.v`. This is what specifications of
-  `std::initializer_list` should be written against. Its interface is the global
-  instances `initializer_listR_cfractional`, `initializer_listR_type_ptr` and
-  `initializer_listR_agree`, plus the derived `initializer_listR_ascfractional`.
-  Destruction is *not* part of it: that goes through the standard library's
-  destructor specification, which consumes the predicate directly.
-
-  It is abstract because `std::initializer_list` has no specified data members,
-  so every conforming representation is isomorphic to the (base pointer, element
-  count) pair the predicate carries. The rationale is stated in full at
-  `initializer_listR`; it is not repeated elsewhere.
-
-  `ety` is the class's **template argument**, not the backing array's element
-  type — <http://eel.is/c++draft/dcl.init.list#5> makes the array `const ety[n]`,
-  so the two differ by that `const`. See `std_initializer_list_element` in
-  `lang/cpp/syntax/types.v`.
-- New `Tstd_initializer_list ety` abbreviation and
-  `std_initializer_list_element` in `lang/cpp/syntax/types.v`, alongside the
-  existing `std_initializer_list` name.
-- `wp_init_initlist_std` grants `initializer_listR` for the backing array it
-  evaluates. It requires the class to be `std::initializer_list<E>` and the
-  backing array to be `const E[N]` for that same `E`.
-  `lang/cpp/syntax/typed.v` checks a weaker condition — it does not require a
-  known extent — so `cpp2v --check-types` rejects malformed nodes but accepting
-  a node does not by itself mean the rule applies to it.
+- `wp_init_initlist_std` reduces it to the `std::initializer_list` constructor
+  named by `std_initlist_ctor` (`lang/cpp/syntax/types.v`), following
+  `wp_init_binop_spaceship`. The representation of the resulting object belongs
+  to whoever specifies that constructor; see `brick-libcpp`.
 - The lifetime-extended case, e.g. `std::initializer_list<int> il = {1,2,3};`,
   is still unsupported because it requires scope-extruded temporaries.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,40 @@ of the release, and introduce a new heading.
 
 ## Since Last Release
 
+2026.07.29: Add support for clang's `CXXStdInitializerListExpr`, i.e. the
+implicit construction of a `std::initializer_list<E>` from a braced-init-list
+(<http://eel.is/c++draft/dcl.init.list#5>).
+- New `Expr` constructor `Einitlist_std (backing : Expr) (t : type)`. Downstream
+  exhaustive matches over `Expr` need a new case.
+- New **abstract** representation predicate `initializer_listR ety q arrayp n`
+  in `lang/cpp/logic/expr.v`. This is what specifications of
+  `std::initializer_list` should be written against. Its interface is the global
+  instances `initializer_listR_cfractional`, `initializer_listR_type_ptr` and
+  `initializer_listR_agree`, plus the derived `initializer_listR_ascfractional`.
+  Destruction is *not* part of it: that goes through the standard library's
+  destructor specification, which consumes the predicate directly.
+
+  It is abstract because `std::initializer_list` has no specified data members,
+  so every conforming representation is isomorphic to the (base pointer, element
+  count) pair the predicate carries. The rationale is stated in full at
+  `initializer_listR`; it is not repeated elsewhere.
+
+  `ety` is the class's **template argument**, not the backing array's element
+  type — <http://eel.is/c++draft/dcl.init.list#5> makes the array `const ety[n]`,
+  so the two differ by that `const`. See `std_initializer_list_element` in
+  `lang/cpp/syntax/types.v`.
+- New `Tstd_initializer_list ety` abbreviation and
+  `std_initializer_list_element` in `lang/cpp/syntax/types.v`, alongside the
+  existing `std_initializer_list` name.
+- `wp_init_initlist_std` grants `initializer_listR` for the backing array it
+  evaluates. It requires the class to be `std::initializer_list<E>` and the
+  backing array to be `const E[N]` for that same `E`.
+  `lang/cpp/syntax/typed.v` checks a weaker condition — it does not require a
+  known extent — so `cpp2v --check-types` rejects malformed nodes but accepting
+  a node does not by itself mean the rule applies to it.
+- The lifetime-extended case, e.g. `std::initializer_list<int> il = {1,2,3};`,
+  is still unsupported because it requires scope-extruded temporaries.
+
 2025.03.20: Change global prefix `bedrock.xxx` to `bluerock.xxx`
 - See `scripts/fm-refactorings/bedrock-bluerock.sh`
 

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
@@ -29,6 +29,26 @@ Require Import skylabs.lang.cpp.logic.dispatch.
 Require Import skylabs.lang.cpp.logic.func.
 Require Import skylabs.iris.extra.bi.errors.
 
+(**
+[std_initlist_ctor_available tu cls aety] holds when [cls] declares the
+constructor that [wp_init_initlist_std] reduces [Einitlist_std] to.
+
+NOTE [Nctor] names carry their parameter types, so finding [std_initlist_ctor]
+under this name *is* finding the <<(const E*, size_t)>> signature; there is
+nothing further to compare. See [std_initlist_ctor] in ../syntax/types.v for why
+that signature, and not another, is the one we target.
+
+It lives here rather than beside [std_initlist_ctor] because
+<<syntax/translation_unit.v>> requires <<syntax/types.v>>, so [types.v] cannot
+mention a [translation_unit].
+*)
+Definition std_initlist_ctor_available
+    (tu : translation_unit) (cls : name) (aety : type) : bool :=
+  match tu.(symbols) !! std_initlist_ctor cls aety with
+  | Some (Oconstructor _) => true
+  | _ => false
+  end.
+
 Module Type Expr.
   (* Needed for [Unfold wp_test] *)
   #[local] Arguments wp_test [_ _ _ _] _ _ _.
@@ -48,82 +68,6 @@ Module Type Expr.
           use [wp_operand] to specify the semantics of any expression that is guaranteed
           to return a primitive.
    *)
-
-  (** ** <<std::initializer_list>>
-
-  [initializer_listR ety q arrayp n] is ownership of a
-  <<std::initializer_list<ety> >> object referring to a backing array of [n]
-  elements at [arrayp] (<https://eel.is/c++draft/dcl.init.list#5>).
-
-  NOTE [ety] is the *class's template argument*, not the backing array's element
-  type: [dcl.init.list#5] gives that array the type <<const ety[n]>>, so the two
-  differ by exactly that <<const>> whenever [ety] is unqualified. Indexing by the
-  template argument is what keeps this predicate and the class of the object it
-  describes in agreement; see [std_initializer_list_element] in
-  ../syntax/types.v.
-
-  *** Why this is abstract
-
-  <https://eel.is/c++draft/initializer.list.syn> specifies only <<begin()>>,
-  <<end()>> and <<size()>>, and declares no data members: how an
-  implementation refers to the backing array is unspecified. But the three
-  accessors pin the *information content* exactly -- <<end() - begin() ==
-  size()>> -- so every conforming representation is isomorphic to the pair
-  ([arrayp], [n]) that this predicate carries. Nothing is lost by declining to
-  name fields, and BRiCk thereby avoids committing to any particular standard
-  library, or to how clang chooses to lay one out.
-
-  This is the canonical statement of that rationale. [Einitlist_std] in
-  ../syntax/core.v, [wp_init_initlist_std] below, and the <<std.initializer_list>>
-  specifications in brick-libcpp refer here rather than repeat it.
-
-  *** What it owns
-
-  Only the <<initializer_list>> object itself, i.e. the "spine". The backing
-  array is a separate resource at [arrayp], held by whoever created it: its
-  storage has automatic duration tied to the materialized temporary, not to this
-  object. Callers pair this with [arrayp |-> arrayR ...].
-
-  NOTE there is deliberately no <<initializer_listR ... |-- anyR ...>> axiom.
-  Destroying one of these objects goes through the destructor specification the
-  standard library provides (<<std.initializer_list.dtor>> in brick-libcpp), which
-  consumes the spine directly; an [anyR] entailment here would be a second, unused
-  route to the same thing.
-
-  NOTE the interface below is what specifications of <<std::initializer_list>>
-  are written against, so it is the expensive thing to change. Should we ever
-  want to *prove* a standard library rather than axiomatize it, this predicate
-  can be given a definition in terms of that library's fields, at which point
-  these instances become theorems and no specification stated in terms of them
-  needs to change.
-  *)
-  Parameter initializer_listR : forall `{Σ : cpp_logic, σ : genv}
-    (ety : type) (q : cQp.t) (arrayp : ptr) (n : N), Rep.
-
-  Section initializer_listR.
-    Context `{Σ : cpp_logic, σ : genv}.
-
-    (** Ownership is fractional, so a <<const>> list can be shared. *)
-    #[global] Declare Instance initializer_listR_cfractional ety arrayp n :
-      CFractional (fun q => initializer_listR ety q arrayp n).
-
-    (** The object exists and has the right type. Without this one cannot call
-        a member function on it, since the call machinery needs the object.
-
-        NOTE [Tstd_initializer_list ety] is the class of the object built by
-        [wp_init_initlist_std], exactly -- not merely up to qualifiers. That is
-        the point of taking [ety] from the class rather than from the backing
-        array. *)
-    #[global] Declare Instance initializer_listR_type_ptr ety q arrayp n :
-      Observe (type_ptrR (Tstd_initializer_list ety))
-              (initializer_listR ety q arrayp n).
-
-    (** Two fractions of the same object refer to the same backing array. *)
-    #[global] Declare Instance initializer_listR_agree ety q q' arrayp arrayp' n n' :
-      Observe2 [| arrayp = arrayp' /\ n = n' |]
-        (initializer_listR ety q  arrayp  n)
-        (initializer_listR ety q' arrayp' n').
-  End initializer_listR.
 
   Section with_resolve.
     Context `{Σ : cpp_logic} {resolve:genv}.
@@ -2037,50 +1981,36 @@ Module Type Expr.
 
     (** ** <<std::initializer_list>>
 
-        [Einitlist_std backing ty] evaluates [backing] to get the address of the
-        backing array of <https://eel.is/c++draft/dcl.init.list#5> and then
-        builds the <<std::initializer_list>> object at [base] referring to it.
+        [Einitlist_std backing ty] is the implicit construction of a
+        <<std::initializer_list<E> >> from the backing array [backing], of type
+        <<const E[N]>> (<https://eel.is/c++draft/dcl.init.list#5>).
 
-        The resulting object is described by [initializer_listR] (declared at
-        the top of this file), which is abstract; see the rationale there. In
-        particular this rule commits to no field layout, and so to none of
-        clang's choices about one.
+        The class has no specified data members, so rather than describe the
+        result directly this rule reduces to the constructor call that builds it
+        -- following [wp_init_binop_spaceship] above -- and leaves the
+        representation to whoever specifies that constructor. [backing] is a
+        subexpression of that call, so its evaluation and [FreeTemps] are the
+        call machinery's job.
 
-        NOTE the backing array is a temporary, so its storage (and the
-        corresponding [FreeTemps]) come from the [Ematerialize_temp] that
-        [backing] wraps. Consequently this rule only covers backing arrays whose
-        lifetime ends with the enclosing full-expression. The lifetime-extended
-        case, e.g. <<std::initializer_list<int> il = {1,2,3};>>, additionally
-        requires support for scope-extruded temporaries, which BRiCk does not
-        yet have; cpp2v emits [Eunsupported] for those.
+        See [std_initlist_ctor] in ../syntax/types.v, which names the
+        constructor and records why that signature. The third side condition
+        requires [tu] to actually declare it, so the rule is inapplicable -- not
+        wrong -- on a standard library that provides a different form. The class
+        and the backing array are checked by [decltype.of_expr] in
+        ../syntax/typed.v, so <<cpp2v --check-types>> rejects malformed nodes.
 
-        NOTE <<const>>ness is carried by the fraction rather than by
-        [wp_make_const]: with an abstract representation there are no subobjects
-        to mark.
-
-        NOTE ../syntax/typed.v checks a *weaker* condition than the side
-        conditions below: it agrees on the class and on the array's element type,
-        but accepts any array shape that [array_type] does -- including
-        [Tincomplete_array] and [Tvariable_array] -- whereas this rule needs the
-        extent [n] and so applies only to [Tarray]. [dcl.init.list#5] fixes the
-        type to <<const E[N]>>, so clang cannot produce the other two here; but a
-        node accepted by <<cpp2v --check-types>> is not by that fact alone one
-        this rule applies to. *)
-    Axiom wp_init_initlist_std : forall cls (base : ptr) cv ty backing ety (n : N) Q,
+        NOTE this covers only backing arrays whose lifetime ends with the
+        enclosing full-expression. The lifetime-extended case, e.g.
+        <<std::initializer_list<int> il = {1,2,3};>>, additionally requires
+        scope-extruded temporaries, which BRiCk does not yet have; cpp2v emits
+        [Eunsupported] for those. *)
+    Axiom wp_init_initlist_std : forall cls (base : ptr) cv ty backing aety (n : N) Q,
         decompose_type ty = (cv, Tnamed cls) ->
-        (* <<E>> is read off the class, so [Tnamed cls] is
-           [Tstd_initializer_list ety] exactly; see
-           [std_initializer_list_element] in ../syntax/types.v for why it is not
-           recovered from the backing array instead. *)
-        std_initializer_list_element cls = Some ety ->
-        (* [dcl.init.list#5]: [backing] is a glvalue of type <<const E[N]>>. The
-           qualifier sits on the element type, but we are defensive about an
-           outer one. *)
-        drop_qualifiers (drop_reference (type_of backing))
-          = Tarray (tqualified QC ety) n ->
-        (letI* arrayp, free := wp_glval backing in
-         base |-> initializer_listR ety (cQp.mk (q_const cv) 1) arrayp n -*
-         Q free)
+        drop_qualifiers (drop_reference (type_of backing)) = Tarray aety n ->
+        std_initlist_ctor_available tu cls aety = true ->
+        wp_init ty base
+          (Econstructor (std_initlist_ctor cls aety)
+             [Ecast Carray2ptr backing; Eint (Z.of_N n) Tsize_t] ty) Q
       |-- wp_init ty base (Einitlist_std backing ty) Q.
 
   End with_resolve.
@@ -2260,17 +2190,3 @@ Declare Module E : Expr.
 Export E.
 
 Export cfrac.
-
-(** [std_initializer_list] in ../syntax/types.v spells the class name out,
-    because the <<cpp_name>> parser depends on that file. Check the two agree. *)
-Succeed Example TEST_std_initializer_list_name :
-  std_initializer_list = "std::initializer_list"%cpp_name := eq_refl.
-
-(** Follows from [initializer_listR_cfractional]; it is what lets the IPM see
-    [initializer_listR] as fractional when solving for a fraction. It cannot be
-    declared alongside the other instances in [Expr], since it has a proof. *)
-#[global] Instance initializer_listR_ascfractional `{Σ : cpp_logic, σ : genv}
-    (ety : type) (arrayp : ptr) (n : N) (q : cQp.t) :
-  AsCFractional (initializer_listR ety q arrayp n)
-    (fun q => initializer_listR ety q arrayp n) q.
-Proof. solve_as_cfrac. Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
@@ -49,6 +49,82 @@ Module Type Expr.
           to return a primitive.
    *)
 
+  (** ** <<std::initializer_list>>
+
+  [initializer_listR ety q arrayp n] is ownership of a
+  <<std::initializer_list<ety> >> object referring to a backing array of [n]
+  elements at [arrayp] (<https://eel.is/c++draft/dcl.init.list#5>).
+
+  NOTE [ety] is the *class's template argument*, not the backing array's element
+  type: [dcl.init.list#5] gives that array the type <<const ety[n]>>, so the two
+  differ by exactly that <<const>> whenever [ety] is unqualified. Indexing by the
+  template argument is what keeps this predicate and the class of the object it
+  describes in agreement; see [std_initializer_list_element] in
+  ../syntax/types.v.
+
+  *** Why this is abstract
+
+  <https://eel.is/c++draft/initializer.list.syn> specifies only <<begin()>>,
+  <<end()>> and <<size()>>, and declares no data members: how an
+  implementation refers to the backing array is unspecified. But the three
+  accessors pin the *information content* exactly -- <<end() - begin() ==
+  size()>> -- so every conforming representation is isomorphic to the pair
+  ([arrayp], [n]) that this predicate carries. Nothing is lost by declining to
+  name fields, and BRiCk thereby avoids committing to any particular standard
+  library, or to how clang chooses to lay one out.
+
+  This is the canonical statement of that rationale. [Einitlist_std] in
+  ../syntax/core.v, [wp_init_initlist_std] below, and the <<std.initializer_list>>
+  specifications in brick-libcpp refer here rather than repeat it.
+
+  *** What it owns
+
+  Only the <<initializer_list>> object itself, i.e. the "spine". The backing
+  array is a separate resource at [arrayp], held by whoever created it: its
+  storage has automatic duration tied to the materialized temporary, not to this
+  object. Callers pair this with [arrayp |-> arrayR ...].
+
+  NOTE there is deliberately no <<initializer_listR ... |-- anyR ...>> axiom.
+  Destroying one of these objects goes through the destructor specification the
+  standard library provides (<<std.initializer_list.dtor>> in brick-libcpp), which
+  consumes the spine directly; an [anyR] entailment here would be a second, unused
+  route to the same thing.
+
+  NOTE the interface below is what specifications of <<std::initializer_list>>
+  are written against, so it is the expensive thing to change. Should we ever
+  want to *prove* a standard library rather than axiomatize it, this predicate
+  can be given a definition in terms of that library's fields, at which point
+  these instances become theorems and no specification stated in terms of them
+  needs to change.
+  *)
+  Parameter initializer_listR : forall `{Σ : cpp_logic, σ : genv}
+    (ety : type) (q : cQp.t) (arrayp : ptr) (n : N), Rep.
+
+  Section initializer_listR.
+    Context `{Σ : cpp_logic, σ : genv}.
+
+    (** Ownership is fractional, so a <<const>> list can be shared. *)
+    #[global] Declare Instance initializer_listR_cfractional ety arrayp n :
+      CFractional (fun q => initializer_listR ety q arrayp n).
+
+    (** The object exists and has the right type. Without this one cannot call
+        a member function on it, since the call machinery needs the object.
+
+        NOTE [Tstd_initializer_list ety] is the class of the object built by
+        [wp_init_initlist_std], exactly -- not merely up to qualifiers. That is
+        the point of taking [ety] from the class rather than from the backing
+        array. *)
+    #[global] Declare Instance initializer_listR_type_ptr ety q arrayp n :
+      Observe (type_ptrR (Tstd_initializer_list ety))
+              (initializer_listR ety q arrayp n).
+
+    (** Two fractions of the same object refer to the same backing array. *)
+    #[global] Declare Instance initializer_listR_agree ety q q' arrayp arrayp' n n' :
+      Observe2 [| arrayp = arrayp' /\ n = n' |]
+        (initializer_listR ety q  arrayp  n)
+        (initializer_listR ety q' arrayp' n').
+  End initializer_listR.
+
   Section with_resolve.
     Context `{Σ : cpp_logic} {resolve:genv}.
     Variables (tu : translation_unit) (ρ : region).
@@ -1959,6 +2035,54 @@ Module Type Expr.
          end)
       |-- wp_init ty base (Einitlist_union fld e ty) Q.
 
+    (** ** <<std::initializer_list>>
+
+        [Einitlist_std backing ty] evaluates [backing] to get the address of the
+        backing array of <https://eel.is/c++draft/dcl.init.list#5> and then
+        builds the <<std::initializer_list>> object at [base] referring to it.
+
+        The resulting object is described by [initializer_listR] (declared at
+        the top of this file), which is abstract; see the rationale there. In
+        particular this rule commits to no field layout, and so to none of
+        clang's choices about one.
+
+        NOTE the backing array is a temporary, so its storage (and the
+        corresponding [FreeTemps]) come from the [Ematerialize_temp] that
+        [backing] wraps. Consequently this rule only covers backing arrays whose
+        lifetime ends with the enclosing full-expression. The lifetime-extended
+        case, e.g. <<std::initializer_list<int> il = {1,2,3};>>, additionally
+        requires support for scope-extruded temporaries, which BRiCk does not
+        yet have; cpp2v emits [Eunsupported] for those.
+
+        NOTE <<const>>ness is carried by the fraction rather than by
+        [wp_make_const]: with an abstract representation there are no subobjects
+        to mark.
+
+        NOTE ../syntax/typed.v checks a *weaker* condition than the side
+        conditions below: it agrees on the class and on the array's element type,
+        but accepts any array shape that [array_type] does -- including
+        [Tincomplete_array] and [Tvariable_array] -- whereas this rule needs the
+        extent [n] and so applies only to [Tarray]. [dcl.init.list#5] fixes the
+        type to <<const E[N]>>, so clang cannot produce the other two here; but a
+        node accepted by <<cpp2v --check-types>> is not by that fact alone one
+        this rule applies to. *)
+    Axiom wp_init_initlist_std : forall cls (base : ptr) cv ty backing ety (n : N) Q,
+        decompose_type ty = (cv, Tnamed cls) ->
+        (* <<E>> is read off the class, so [Tnamed cls] is
+           [Tstd_initializer_list ety] exactly; see
+           [std_initializer_list_element] in ../syntax/types.v for why it is not
+           recovered from the backing array instead. *)
+        std_initializer_list_element cls = Some ety ->
+        (* [dcl.init.list#5]: [backing] is a glvalue of type <<const E[N]>>. The
+           qualifier sits on the element type, but we are defensive about an
+           outer one. *)
+        drop_qualifiers (drop_reference (type_of backing))
+          = Tarray (tqualified QC ety) n ->
+        (letI* arrayp, free := wp_glval backing in
+         base |-> initializer_listR ety (cQp.mk (q_const cv) 1) arrayp n -*
+         Q free)
+      |-- wp_init ty base (Einitlist_std backing ty) Q.
+
   End with_resolve.
 
   (* `Earrayloop_init` needs to extend the region, so we need to start a new section. *)
@@ -2136,3 +2260,17 @@ Declare Module E : Expr.
 Export E.
 
 Export cfrac.
+
+(** [std_initializer_list] in ../syntax/types.v spells the class name out,
+    because the <<cpp_name>> parser depends on that file. Check the two agree. *)
+Succeed Example TEST_std_initializer_list_name :
+  std_initializer_list = "std::initializer_list"%cpp_name := eq_refl.
+
+(** Follows from [initializer_listR_cfractional]; it is what lets the IPM see
+    [initializer_listR] as fractional when solving for a fraction. It cannot be
+    declared alongside the other instances in [Expr], since it has a proof. *)
+#[global] Instance initializer_listR_ascfractional `{Σ : cpp_logic, σ : genv}
+    (ety : type) (arrayp : ptr) (n : N) (q : cQp.t) :
+  AsCFractional (initializer_listR ety q arrayp n)
+    (fun q => initializer_listR ety q arrayp n) q.
+Proof. solve_as_cfrac. Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/expr.v
@@ -1995,9 +1995,9 @@ Module Type Expr.
         See [std_initlist_ctor] in ../syntax/types.v, which names the
         constructor and records why that signature. The third side condition
         requires [tu] to actually declare it, so the rule is inapplicable -- not
-        wrong -- on a standard library that provides a different form. The class
-        and the backing array are checked by [decltype.of_expr] in
-        ../syntax/typed.v, so <<cpp2v --check-types>> rejects malformed nodes.
+        wrong -- on a standard library that provides a different form. The
+        [decltype.of_expr] premise typechecks the node we produce; it is weak
+        today, but it is the hook for a stricter check.
 
         NOTE this covers only backing arrays whose lifetime ends with the
         enclosing full-expression. The lifetime-extended case, e.g.
@@ -2008,9 +2008,10 @@ Module Type Expr.
         decompose_type ty = (cv, Tnamed cls) ->
         drop_qualifiers (drop_reference (type_of backing)) = Tarray aety n ->
         std_initlist_ctor_available tu cls aety = true ->
-        wp_init ty base
-          (Econstructor (std_initlist_ctor cls aety)
-             [Ecast Carray2ptr backing; Eint (Z.of_N n) Tsize_t] ty) Q
+        (let e := Econstructor (std_initlist_ctor cls aety)
+                    [Ecast Carray2ptr backing; Eint (Z.of_N n) Tsize_t] ty in
+         [| decltype.of_expr e = Some ty |] ∗
+         wp_init ty base e Q)
       |-- wp_init ty base (Einitlist_std backing ty) Q.
 
   End with_resolve.

--- a/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/mparser/expr.v
@@ -317,6 +317,7 @@ Fixpoint to_unresolved_name (e : MExpr) : Mname :=
   | Enull => Nunsupported "Enull"
   | Einitlist _ _ _ => Nunsupported "Einitlist"
   | Einitlist_union _ _ _ => Nunsupported "Einitlist_union"
+  | Einitlist_std _ _ => Nunsupported "Einitlist_std"
   | Enew _ _ _ _ _ _ => Nunsupported "Enew"
   | Edelete _ _ _ _ => Nunsupported "Edelete"
   | Eatomic _ _ _ => Nunsupported "Eatomic"

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/compare.v
@@ -1727,6 +1727,14 @@ Module Expr.
       compare_lex (option.compare compareE b1.(box_Einitlist_union_1) b2.(box_Einitlist_union_1)) $ fun _ =>
       compareT b1.(box_Einitlist_union_2) b2.(box_Einitlist_union_2).
 
+    Record box_Einitlist_std : Set := Box_Einitlist_std {
+      box_Einitlist_std_0 : Expr;
+      box_Einitlist_std_1 : type;
+    }.
+    Definition box_Einitlist_std_compare (b1 b2 : box_Einitlist_std) : comparison :=
+      compare_lex (compareE b1.(box_Einitlist_std_0) b2.(box_Einitlist_std_0)) $ fun _ =>
+      compareT b1.(box_Einitlist_std_1) b2.(box_Einitlist_std_1).
+
     Record box_Enew : Set := Box_Enew {
       box_Enew_0 : name * type;
       box_Enew_1 : list Expr;
@@ -1878,6 +1886,7 @@ Module Expr.
       | Enull => 44
       | Einitlist _ _ _ => 45
       | Einitlist_union _ _ _ => 60
+      | Einitlist_std _ _ => 68
       | Enew _ _ _ _ _ _ => 46
       | Edelete _ _ _ _ => 47
       | Eandclean _ => 48
@@ -1955,6 +1964,7 @@ Module Expr.
       | 65 => box_Eunresolved_initlist
       | 66 => box_Eunresolved_sizeof_pack
       | 67 => box_Einherited_constructor
+      | 68 => box_Einitlist_std
       | _ => box_Eunsupported
       end.
     Definition data (e : Expr) : car (tag e) :=
@@ -2014,6 +2024,7 @@ Module Expr.
       | Enull => ()
       | Einitlist es i t => Box_Einitlist es i t
       | Einitlist_union es i t => Box_Einitlist_union es i t
+      | Einitlist_std e t => Box_Einitlist_std e t
       | Enew fn es a ty sz i => Box_Enew fn es a ty sz i
       | Edelete a fn e t => Box_Edelete a fn e t
       | Eandclean e => e
@@ -2089,6 +2100,7 @@ Module Expr.
       | 65 => box_Eunresolved_initlist_compare
       | 66 => box_Eunresolved_sizeof_pack_compare
       | 67 => box_Einherited_constructor_compare
+      | 68 => box_Einitlist_std_compare
       | _ => box_Eunsupported_compare
       end.
 
@@ -2166,6 +2178,7 @@ Module Expr.
 
       | Einitlist es i t => COMP (Einitlist es i t)
       | Einitlist_union es i t => COMP (Einitlist_union es i t)
+      | Einitlist_std e t => COMP (Einitlist_std e t)
 
       | Enew fn es a ty sz i => COMP (Enew fn es a ty sz i)
       | Edelete a fn e t => COMP (Edelete a fn e t)

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -407,6 +407,27 @@ Should be [gn : classname]
 | Enull
 | Einitlist (args : list Expr) (default : option Expr) (t : type)
 | Einitlist_union (_ : atomic_name) (_ : option Expr) (t : type)
+(**
+[Einitlist_std backing t] is the implicit construction of the
+<<std::initializer_list<E>>> object of type [t] that refers to the backing
+array [backing] (of type <<const E[N]>>).
+See <https://eel.is/c++draft/dcl.init.list#5>; in clang this is
+[CXXStdInitializerListExpr].
+
+The expression is always a prvalue of class type, so it is consumed by
+[wp_init].
+
+NOTE: <https://eel.is/c++draft/initializer.list.syn> declares *no* data
+members for <<std::initializer_list>>, so how the object refers to [backing]
+is implementation defined. Implementations pick one of two two-field layouts,
+<<{ const E* first; size_t size; }>> (libstdc++, libc++) or
+<<{ const E* first; const E* last; }>> (MSVC STL). Rather than commit to
+either, the semantics describes the object with an abstract representation
+predicate carrying just the backing array's base pointer and element count.
+See [initializer_listR] in ../logic/expr.v, which states the rationale, and
+[wp_init_initlist_std], which builds one.
+*)
+| Einitlist_std (backing : Expr) (t : type)
 
 | Enew (new_fn : name * type) (new_args : list Expr) (pass_align : new_form)
   (alloc_ty : type) (array_size : option Expr) (init : option Expr)
@@ -1037,6 +1058,7 @@ with is_dependentE (e : Expr) : bool :=
   | Enull => false
   | Einitlist es eo t => existsb is_dependentE es || option.existsb is_dependentE eo || is_dependentT t
   | Einitlist_union f oe t => option.existsb is_dependentE oe || is_dependentT t
+  | Einitlist_std e t => is_dependentE e || is_dependentT t
 
   | Enew p es _ t e1 e2 => is_dependentN p.1 || is_dependentT p.2 || existsb is_dependentE es || is_dependentT t || option.existsb is_dependentE e1 || option.existsb is_dependentE e2
   | Edelete _ p e t => is_dependentN p || is_dependentE e || is_dependentT t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/core.v
@@ -415,17 +415,7 @@ See <https://eel.is/c++draft/dcl.init.list#5>; in clang this is
 [CXXStdInitializerListExpr].
 
 The expression is always a prvalue of class type, so it is consumed by
-[wp_init].
-
-NOTE: <https://eel.is/c++draft/initializer.list.syn> declares *no* data
-members for <<std::initializer_list>>, so how the object refers to [backing]
-is implementation defined. Implementations pick one of two two-field layouts,
-<<{ const E* first; size_t size; }>> (libstdc++, libc++) or
-<<{ const E* first; const E* last; }>> (MSVC STL). Rather than commit to
-either, the semantics describes the object with an abstract representation
-predicate carrying just the backing array's base pointer and element count.
-See [initializer_listR] in ../logic/expr.v, which states the rationale, and
-[wp_init_initlist_std], which builds one.
+[wp_init]; see [wp_init_initlist_std] in ../logic/expr.v.
 *)
 | Einitlist_std (backing : Expr) (t : type)
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/mtraverse.v
@@ -274,6 +274,7 @@ Module MTraverse.
           Einitlist <$> traverse (T:=eta list) traverseE es <*> traverse (T:=eta option) traverseE oe <*> ET (traverseT t)
       | Einitlist_union fld oe t =>
           Einitlist_union <$> atomic_name.traverse traverseT fld <*> traverse (T:=eta option) traverseE oe <*> ET (traverseT t)
+      | Einitlist_std e t => Einitlist_std <$> traverseE e <*> ET (traverseT t)
 
       | Enew fn es pass_align t sz init => Enew <$> prod.traverse traverseN traverseT fn <*> traverse (T:=eta list) traverseE es <*> mret pass_align <*> traverseT t <*> traverse (T:=eta option) traverseE sz <*> traverse (T:=eta option) traverseE init
       | Edelete a fn e t => Edelete a <$> traverseN fn <*> traverseE e <*> traverseT t

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/supported.v
@@ -221,6 +221,7 @@ Section with_monad.
     | Epseudo_destructor _ t e => type t <+> expr e
     | Einitlist es oe t => lst expr es <+> opt expr oe <+> type t
     | Einitlist_union _ oe t => opt expr oe <+> type t
+    | Einitlist_std e t => expr e <+> type t
     | Emember_call _ mr e es =>
         match mr with
         | inr e => expr e

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -870,6 +870,36 @@ Module decltype.
               end
             in
             mret t
+        | Einitlist_std e t =>
+            (**
+            The sub-expression is the backing array of
+            <https://eel.is/c++draft/dcl.init.list#5>, i.e. a glvalue of type
+            <<const E[N]>>. The node itself is a prvalue of class type.
+
+            NOTE this is *weaker* than what [wp_init_initlist_std] in
+            ../logic/expr.v requires: that rule needs the array's extent, so it
+            applies only to [Tarray], whereas [array_type] below also accepts
+            [Tincomplete_array] and [Tvariable_array]. [dcl.init.list#5] fixes
+            the type to <<const E[N]>>, so clang cannot produce those here, but
+            a node accepted by <<cpp2v --check-types>> is not by that fact alone
+            one the rule applies to.
+            *)
+            let* bt := of_expr e in
+            let* cls :=
+              match drop_qualifiers t with
+              | Tnamed cls => mret cls
+              | _ => mfail
+              end
+            in
+            (* <<E>> comes from the class, and the backing array's element type
+               must then be <<const E>>; see [std_initializer_list_element] in
+               types.v for why <<E>> is not read off the array instead. *)
+            let* ety := of_option $ std_initializer_list_element cls in
+            let* aety := of_option $ array_type $ drop_reference bt in
+            let* _ :=
+              if bool_decide (aety = tqualified QC ety) then mret () else mfail
+            in
+            mret t
         | Enew (alloc, alloc_ty) aes nf aty osz oinit =>
             let* ats := traverse (T:=eta list) of_expr aes in
             let* afty := require_functype alloc_ty in
@@ -1197,3 +1227,47 @@ Section exprtype.
 
 End exprtype.
 End exprtype.
+
+(** ** Tests for [Einitlist_std]
+
+    <https://eel.is/c++draft/dcl.init.list#5> requires the result to be
+    <<std::initializer_list<E>>> and the backing array to be <<const E[N]>> for
+    that same <<E>>. Checking that here means a malformed node is reported by
+    <<cpp2v --check-types>> instead of surfacing as an unprovable goal deep in
+    a proof. *)
+Section Einitlist_std_tests.
+  (** <<const int[3]>>, the backing array for both <<std::initializer_list<int> >>
+      and <<std::initializer_list<const int> >>: the <<const>> that
+      [dcl.init.list#5] adds is idempotent, so the array does not determine which
+      of the two classes is being built. *)
+  #[local] Definition backing : Expr :=
+    Ematerialize_temp
+      (Einitlist [Eint 1 Tint; Eint 2 Tint; Eint 3 Tint] None
+         (Tarray (Tconst Tint) 3)) Xvalue.
+  #[local] Definition accepts (t : type) : bool :=
+    if trace.runO (decltype.of_expr empty (Einitlist_std backing t))
+    then true else false.
+
+  Succeed Example TEST_accept :
+    accepts (Tstd_initializer_list Tint) = true := eq_refl.
+
+  (** Accepted: <<E>> may itself be <<const>>-qualified, and then <<const E>> is
+      <<E>>. Both this and [TEST_accept] are legitimate, which is why <<E>> has
+      to come from the class -- see [std_initializer_list_element] in types.v. *)
+  Succeed Example TEST_accept_const_elem :
+    accepts (Tstd_initializer_list (Tconst Tint)) = true := eq_refl.
+
+  (** Rejected: the template argument disagrees with the array element type. *)
+  Succeed Example TEST_reject_elem :
+    accepts (Tstd_initializer_list Tbool) = false := eq_refl.
+  (** Rejected: a class that is not <<std::initializer_list>>. *)
+  Succeed Example TEST_reject_class :
+    accepts (Tnamed (Nglobal (Nid "my_span"))) = false := eq_refl.
+  (** Rejected: not a class type at all. *)
+  Succeed Example TEST_reject_prim : accepts Tint = false := eq_refl.
+  (** Rejected: the sub-expression is not a backing array. *)
+  Succeed Example TEST_reject_nonarray :
+    (if trace.runO (decltype.of_expr empty
+                      (Einitlist_std (Eint 1 Tint) (Tstd_initializer_list Tint)))
+     then true else false) = false := eq_refl.
+End Einitlist_std_tests.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typed.v
@@ -11,6 +11,7 @@ Require Import skylabs.lang.cpp.syntax.typing.
 Require Import skylabs.lang.cpp.syntax.stmt.
 Require Import skylabs.lang.cpp.syntax.namemap.
 Require Import skylabs.lang.cpp.syntax.translation_unit.
+Require Import skylabs.lang.cpp.syntax.name_notation.
 Import UPoly.
 
 #[local] Open Scope monad_scope.
@@ -19,6 +20,54 @@ Import UPoly.
 mlock Definition breadcrumb {t : Set} (_ : t) : Error.t := inhabitant.
 mlock Definition Bad_allocation_function_args (_ : list type) : Error.t := inhabitant.
 mlock Definition Can_initialize (dt it : decltype) : Error.t := inhabitant.
+
+(** ** <<std::initializer_list>>
+
+The class from <https://eel.is/c++draft/dcl.init.list#5>. The name is fixed by
+the standard and is never versioned.
+
+NOTE [std_initializer_list] and [Tstd_initializer_list] must be [Abbreviation]s,
+not hidden behind [Definition]s, since ASTs will expand them.
+*)
+Abbreviation std_initializer_list := "std::initializer_list"%cpp_name (only parsing).
+
+(** <<std::initializer_list<ety> >>. *)
+Abbreviation Tstd_initializer_list ety :=
+  (Tnamed (Ninst std_initializer_list [Atype ety])) (only parsing).
+
+(**
+[std_initializer_list_element cls] is the <<E>> of <<std::initializer_list<E> >>,
+when [cls] is that class.
+
+NOTE <<E>> is read off the *class*. [dcl.init.list#5] then fixes the backing
+array to <<const E[N]>>, so recovering <<E>> from the array instead -- by erasing
+qualifiers, say -- would conflate the <<const>> that [dcl.init.list#5] adds with
+one that is genuinely part of <<E>>, and so get
+<<std::initializer_list<const int> >> wrong.
+*)
+Definition std_initializer_list_element (cls : name) : option type :=
+  match cls with
+  | Ninst hd [Atype ety] =>
+      if bool_decide (hd = std_initializer_list) then Some ety else None
+  | _ => None
+  end.
+
+Succeed Example TEST_std_initializer_list_element :
+  std_initializer_list_element (Ninst std_initializer_list [Atype Tint])
+    = Some Tint := eq_refl.
+
+(** The <<const E>> case, which a qualifier-erasing version gets wrong. *)
+Succeed Example TEST_std_initializer_list_element_const :
+  std_initializer_list_element (Ninst std_initializer_list [Atype (Tconst Tint)])
+    = Some (Tconst Tint) := eq_refl.
+
+(** Not <<std::initializer_list>>. *)
+Succeed Example TEST_std_initializer_list_element_other :
+  std_initializer_list_element (Nglobal (Nid "my_span")) = None := eq_refl.
+
+(** Not an instantiation at all. *)
+Succeed Example TEST_std_initializer_list_element_uninst :
+  std_initializer_list_element std_initializer_list = None := eq_refl.
 
 Module decltype.
 
@@ -892,8 +941,8 @@ Module decltype.
               end
             in
             (* <<E>> comes from the class, and the backing array's element type
-               must then be <<const E>>; see [std_initializer_list_element] in
-               types.v for why <<E>> is not read off the array instead. *)
+               must then be <<const E>>; see [std_initializer_list_element]
+               above for why <<E>> is not read off the array instead. *)
             let* ety := of_option $ std_initializer_list_element cls in
             let* aety := of_option $ array_type $ drop_reference bt in
             let* _ :=
@@ -1253,7 +1302,7 @@ Section Einitlist_std_tests.
 
   (** Accepted: <<E>> may itself be <<const>>-qualified, and then <<const E>> is
       <<E>>. Both this and [TEST_accept] are legitimate, which is why <<E>> has
-      to come from the class -- see [std_initializer_list_element] in types.v. *)
+      to come from the class -- see [std_initializer_list_element] above. *)
   Succeed Example TEST_accept_const_elem :
     accepts (Tstd_initializer_list (Tconst Tint)) = true := eq_refl.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/types.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/types.v
@@ -1273,88 +1273,43 @@ End with_lang.
 
 (** ** <<std::initializer_list>>
 
-The class from <https://eel.is/c++draft/dcl.init.list#5>.
+[std_initlist_ctor cls aety] names the constructor that [wp_init_initlist_std]
+(../logic/expr.v) reduces [Einitlist_std] to, for a backing array of element type
+[aety] (i.e. <<const E>>, per <https://eel.is/c++draft/dcl.init.list#5>).
 
-NOTE this name is fixed by the standard and is never versioned: libc++ declares
-<<initializer_list>> *outside* its inline versioning namespace precisely because
-the compiler must be able to find <<std::initializer_list>>.
+<https://eel.is/c++draft/support.initlist> specifies only the default
+constructor, so the one the compiler actually calls is implementation defined.
+clang and gcc pass <<(base, size)>>; the MSVC STL passes <<(base, base + size)>>
+with a slightly different declaration. The two carry the same information and
+will validate the same code, so choosing between them is a technicality -- but a
+reduction has to name one, and we name the clang/gcc form.
 
-We spell the name out rather than using the <<cpp_name>> notation because that
-notation's parser depends on this file. [TEST_std_initializer_list_name] in
-../logic/expr.v checks the two agree.
-
-NOTE [std_initializer_list] and [Tstd_initializer_list] are [Abbreviation]s, not
-[Definition]s, so that a goal mentioning the class contains the name itself. An
-opaque constant could not be matched against the name that specifications use,
-and a transparent one is rejected by the <<sl-transparent-constants>> check when
-it appears under [type_ptr]. They sit outside [with_lang] because a
-section-local [Abbreviation] would be discharged at [End with_lang].
+Nothing is thereby claimed about the other form: [wp_init_initlist_std] takes
+[std_initlist_ctor_available] as a side condition, so on a library declaring only
+the two-pointer constructor the rule simply does not apply. Supporting MSVC would
+mean an alternative rule testing for that overload and/or for the compiler
+flavor, rather than a change here.
 *)
-Abbreviation std_initializer_list :=
-  (Nscoped (Nglobal (Nid "std")) (Nid "initializer_list")) (only parsing).
-
-(** <<std::initializer_list<ety> >>. *)
-Abbreviation Tstd_initializer_list ety :=
-  (Tnamed (Ninst std_initializer_list [Atype ety])) (only parsing).
+Definition std_initlist_ctor (cls : name) (aety : type) : name :=
+  Nscoped cls (Nctor [Tptr aety; Tsize_t]).
 
 (**
-[std_initializer_list_element cls] is the <<E>> of <<std::initializer_list<E> >>,
-when [cls] is that class.
+The same name, computed from the types [Einitlist_std backing ty] carries: [ty]
+is the class and [bty] the backing array's type.
 
-NOTE <<E>> is read off the *class*, not off the backing array. [dcl.init.list#5]
-determines <<E>> from the class and then fixes the backing array's type to
-<<const E[N]>> for that same <<E>>, so the two differ by exactly that <<const>>
-whenever <<E>> is unqualified. Recovering <<E>> from the array instead -- by
-erasing qualifiers, say -- conflates the <<const>> that [dcl.init.list#5] *adds*
-with a <<const>> that is genuinely part of <<E>>, and so gets
-<<std::initializer_list<const int> >> wrong: it would describe such an object
-with an [initializer_listR] indexed by <<int>>, i.e. belonging to a different
-class. [wp_init_initlist_std] in ../logic/expr.v depends on this; see
-[TEST_std_initializer_list_element_const] below.
+This is what the dependency traversal in <<auto/cpp/deps.v>> and the library hint
+that discharges the resulting goal both use, so that all three agree on the name
+by construction.
 *)
-Definition std_initializer_list_element (cls : name) : option type :=
-  match cls with
-  | Ninst hd [Atype ety] =>
-      if bool_decide (hd = std_initializer_list) then Some ety else None
+Definition std_initlist_ctor_of (ty bty : type) : option name :=
+  match drop_qualifiers ty with
+  | Tnamed cls =>
+      match drop_qualifiers (drop_reference bty) with
+      | Tarray aety _ => Some (std_initlist_ctor cls aety)
+      | _ => None
+      end
   | _ => None
   end.
-
-(**
-<<E>> is recovered verbatim, so [Tnamed cls] is [Tstd_initializer_list ety]
-*exactly* -- not merely up to qualifiers.
-
-This is the invariant [wp_init_initlist_std] in ../logic/expr.v relies on to
-describe an object of class [cls] with an [initializer_listR] indexed by [ety]:
-were the two allowed to differ, that rule would hand out [type_ptrR] for a class
-other than the one being constructed.
-*)
-Lemma std_initializer_list_element_inv cls ety :
-  std_initializer_list_element cls = Some ety ->
-  Tnamed cls = Tstd_initializer_list ety.
-Proof.
-  rewrite /std_initializer_list_element.
-  repeat case_match; try discriminate.
-  intros Heq; simplify_eq.
-  match goal with H : bool_decide _ = true |- _ => apply bool_decide_eq_true_1 in H end.
-  by subst.
-Qed.
-
-Succeed Example TEST_std_initializer_list_element :
-  std_initializer_list_element (Ninst std_initializer_list [Atype Tint])
-    = Some Tint := eq_refl.
-
-(** The <<const E>> case, which a qualifier-erasing version gets wrong. *)
-Succeed Example TEST_std_initializer_list_element_const :
-  std_initializer_list_element (Ninst std_initializer_list [Atype (Tconst Tint)])
-    = Some (Tconst Tint) := eq_refl.
-
-(** Not <<std::initializer_list>>. *)
-Succeed Example TEST_std_initializer_list_element_other :
-  std_initializer_list_element (Nglobal (Nid "my_span")) = None := eq_refl.
-
-(** Not an instantiation at all. *)
-Succeed Example TEST_std_initializer_list_element_uninst :
-  std_initializer_list_element std_initializer_list = None := eq_refl.
 
 Notation normalize_type := (normalize_type' QM).
 Notation as_ref := (as_ref' (fun u => u) Tvoid).

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/types.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/types.v
@@ -1271,6 +1271,91 @@ Definition Tmember_func (ty : exprtype) (fty : functype) : functype :=
   end.
 End with_lang.
 
+(** ** <<std::initializer_list>>
+
+The class from <https://eel.is/c++draft/dcl.init.list#5>.
+
+NOTE this name is fixed by the standard and is never versioned: libc++ declares
+<<initializer_list>> *outside* its inline versioning namespace precisely because
+the compiler must be able to find <<std::initializer_list>>.
+
+We spell the name out rather than using the <<cpp_name>> notation because that
+notation's parser depends on this file. [TEST_std_initializer_list_name] in
+../logic/expr.v checks the two agree.
+
+NOTE [std_initializer_list] and [Tstd_initializer_list] are [Abbreviation]s, not
+[Definition]s, so that a goal mentioning the class contains the name itself. An
+opaque constant could not be matched against the name that specifications use,
+and a transparent one is rejected by the <<sl-transparent-constants>> check when
+it appears under [type_ptr]. They sit outside [with_lang] because a
+section-local [Abbreviation] would be discharged at [End with_lang].
+*)
+Abbreviation std_initializer_list :=
+  (Nscoped (Nglobal (Nid "std")) (Nid "initializer_list")) (only parsing).
+
+(** <<std::initializer_list<ety> >>. *)
+Abbreviation Tstd_initializer_list ety :=
+  (Tnamed (Ninst std_initializer_list [Atype ety])) (only parsing).
+
+(**
+[std_initializer_list_element cls] is the <<E>> of <<std::initializer_list<E> >>,
+when [cls] is that class.
+
+NOTE <<E>> is read off the *class*, not off the backing array. [dcl.init.list#5]
+determines <<E>> from the class and then fixes the backing array's type to
+<<const E[N]>> for that same <<E>>, so the two differ by exactly that <<const>>
+whenever <<E>> is unqualified. Recovering <<E>> from the array instead -- by
+erasing qualifiers, say -- conflates the <<const>> that [dcl.init.list#5] *adds*
+with a <<const>> that is genuinely part of <<E>>, and so gets
+<<std::initializer_list<const int> >> wrong: it would describe such an object
+with an [initializer_listR] indexed by <<int>>, i.e. belonging to a different
+class. [wp_init_initlist_std] in ../logic/expr.v depends on this; see
+[TEST_std_initializer_list_element_const] below.
+*)
+Definition std_initializer_list_element (cls : name) : option type :=
+  match cls with
+  | Ninst hd [Atype ety] =>
+      if bool_decide (hd = std_initializer_list) then Some ety else None
+  | _ => None
+  end.
+
+(**
+<<E>> is recovered verbatim, so [Tnamed cls] is [Tstd_initializer_list ety]
+*exactly* -- not merely up to qualifiers.
+
+This is the invariant [wp_init_initlist_std] in ../logic/expr.v relies on to
+describe an object of class [cls] with an [initializer_listR] indexed by [ety]:
+were the two allowed to differ, that rule would hand out [type_ptrR] for a class
+other than the one being constructed.
+*)
+Lemma std_initializer_list_element_inv cls ety :
+  std_initializer_list_element cls = Some ety ->
+  Tnamed cls = Tstd_initializer_list ety.
+Proof.
+  rewrite /std_initializer_list_element.
+  repeat case_match; try discriminate.
+  intros Heq; simplify_eq.
+  match goal with H : bool_decide _ = true |- _ => apply bool_decide_eq_true_1 in H end.
+  by subst.
+Qed.
+
+Succeed Example TEST_std_initializer_list_element :
+  std_initializer_list_element (Ninst std_initializer_list [Atype Tint])
+    = Some Tint := eq_refl.
+
+(** The <<const E>> case, which a qualifier-erasing version gets wrong. *)
+Succeed Example TEST_std_initializer_list_element_const :
+  std_initializer_list_element (Ninst std_initializer_list [Atype (Tconst Tint)])
+    = Some (Tconst Tint) := eq_refl.
+
+(** Not <<std::initializer_list>>. *)
+Succeed Example TEST_std_initializer_list_element_other :
+  std_initializer_list_element (Nglobal (Nid "my_span")) = None := eq_refl.
+
+(** Not an instantiation at all. *)
+Succeed Example TEST_std_initializer_list_element_uninst :
+  std_initializer_list_element std_initializer_list = None := eq_refl.
+
 Notation normalize_type := (normalize_type' QM).
 Notation as_ref := (as_ref' (fun u => u) Tvoid).
 Notation as_ref_option := (as_ref' Some None).

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/typing.v
@@ -340,6 +340,7 @@ Module decltype.
         | Enull => mret Tnullptr
         | Einitlist _ _ t => mret t
         | Einitlist_union _ _ t => mret t
+        | Einitlist_std _ t => mret t
         | Enew _ _ _ aty _ _ => mret $ Tptr aty
         | Edelete _ _ _ _ => mret Tvoid
         | Eandclean e => of_expr e

--- a/rocq-skylabs-cpp2v/src/PrintExpr.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintExpr.cpp
@@ -1329,6 +1329,22 @@ public:
         }
     }
 
+    /// The implicit construction of a <<std::initializer_list<E>>> from the
+    /// backing array of <http://eel.is/c++draft/dcl.init.list#5>.
+    ///
+    /// The sub-expression is printed verbatim: it is a [MaterializeTemporaryExpr]
+    /// wrapping an [InitListExpr] of type <<const E[N]>>, so the backing array's
+    /// storage is handled by the existing temporary machinery. Note that this
+    /// means the lifetime-extended case, e.g.
+    /// <<std::initializer_list<int> il = {1,2,3};>>, reports the
+    /// "scope-extruded temporary" limitation from
+    /// [VisitMaterializeTemporaryExpr].
+    void VisitCXXStdInitializerListExpr(const CXXStdInitializerListExpr *expr) {
+        print.ctor("Einitlist_std");
+        cprint.printExpr(print, expr->getSubExpr(), names) << fmt::nbsp;
+        done(expr);
+    }
+
     void VisitCXXThisExpr(const CXXThisExpr *expr) {
         if (auto maybe_lambda = cprint.getLambdaClass()) {
             auto &[lambda, cv] = maybe_lambda.value();

--- a/rocq-skylabs-cpp2v/tests/std_initializer_list.t/Makefile
+++ b/rocq-skylabs-cpp2v/tests/std_initializer_list.t/Makefile
@@ -1,0 +1,13 @@
+CPPFLAGS = -std=gnu++23
+
+CPP_FILES = $(shell find . -name '*.cpp')
+
+GEN_FILES = \
+  $(CPP_FILES:.cpp=_cpp.v)
+
+Q = @
+
+all: $(GEN_FILES)
+
+%_cpp.v: %.cpp
+	$(Q)cpp2v -v -o $@ $< --check-types --no-elaborate --no-templates -- $(CPPFLAGS)

--- a/rocq-skylabs-cpp2v/tests/std_initializer_list.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/std_initializer_list.t/run.t
@@ -1,0 +1,13 @@
+  $ . ../setup-project.sh
+
+Compiling the C++ code, use "make Q=" for debugging.
+  $ ulimit -S -s 40960
+  $ make 2> /dev/null
+  $ ls *.v | wc -l | sed -e 's/ //g'
+  2
+
+[test.v] states, per function of [test.cpp], where the [Einitlist_std] nodes are
+and whether BRiCk supports that function. Both are scoped to the symbols
+[test.cpp] defines, so nothing that <initializer_list> transitively drags in is
+recorded here, and a regression is a build failure rather than a diff.
+  $ dune build

--- a/rocq-skylabs-cpp2v/tests/std_initializer_list.t/run.t
+++ b/rocq-skylabs-cpp2v/tests/std_initializer_list.t/run.t
@@ -1,4 +1,4 @@
-  $ . ../setup-project.sh
+  $ setup_project
 
 Compiling the C++ code, use "make Q=" for debugging.
   $ ulimit -S -s 40960

--- a/rocq-skylabs-cpp2v/tests/std_initializer_list.t/test.cpp
+++ b/rocq-skylabs-cpp2v/tests/std_initializer_list.t/test.cpp
@@ -1,0 +1,55 @@
+#include <initializer_list>
+
+// [dcl.init.list]#5 / clang's [CXXStdInitializerListExpr].
+//
+// The backing array of a <<std::initializer_list>> is a temporary. Where that
+// temporary's lifetime ends with the enclosing full-expression, BRiCk supports
+// the conversion; where it is lifetime-extended (a "scope-extruded temporary")
+// it does not.
+
+int sum(std::initializer_list<int> l) {
+  int acc = 0;
+  for (auto x : l)
+    acc += x;
+  return acc;
+}
+
+struct Widget {
+  int a;
+  int b;
+};
+
+struct Holder {
+  int n;
+  Holder(std::initializer_list<int> l) : n((int)l.size()) {}
+};
+
+// Supported: the backing array dies with the full-expression.
+int pass_to_function() { return sum({1, 2, 3}); }
+
+int copy_init_class() {
+  Holder h = {1, 2, 3};
+  return h.n;
+}
+
+int direct_init_class() {
+  Holder h{1, 2, 3};
+  return h.n;
+}
+
+int nested_elements() { return sum({1, 2, 3}) + sum({}); }
+
+std::initializer_list<Widget> widgets() { return {{1, 2}, {3, 4}}; }
+
+// Supported, but no [CXXStdInitializerListExpr]: clang uses the default
+// constructor for an empty braced-init-list.
+int empty_list() {
+  std::initializer_list<int> l = {};
+  return (int)l.size();
+}
+
+// Unsupported: the backing array is lifetime-extended to match <<l>>.
+int extended_temporary() {
+  std::initializer_list<int> l = {1, 2, 3};
+  return (int)l.size();
+}

--- a/rocq-skylabs-cpp2v/tests/std_initializer_list.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/std_initializer_list.t/test.v
@@ -1,0 +1,165 @@
+Require Import skylabs.prelude.base.
+Require Import skylabs.lang.cpp.syntax.
+Require skylabs.lang.cpp.syntax.supported.
+
+Require test.test_cpp.
+
+(** * cpp2v's handling of clang's [CXXStdInitializerListExpr]
+
+    [test.cpp] exercises the conversion of a braced-init-list to a
+    <<std::initializer_list<E>>> (<https://eel.is/c++draft/dcl.init.list#5>),
+    which cpp2v prints as [Einitlist_std].
+
+    Two things shape this test.
+
+    - It is scoped to the functions that [test.cpp] itself defines. A check over
+      the whole translation unit — [supported.check.translation_unit], say —
+      also reports every unsupported construct that <<<initializer_list>>>
+      transitively drags in, so its expected output moves whenever the standard
+      library or clang does.
+
+    - It states where the [Einitlist_std] nodes are with [context] patterns
+      naming only the constructors this feature is about. Nothing here depends
+      on what *wraps* a node, so casts, [Eandclean], and the calls or
+      constructors around it are free to change.
+
+    It deliberately does not re-check that a node is well formed. <<--check-types>>
+    (see the [Makefile]) runs [typed.decltype.check_tu] over the whole
+    translation unit, and that already requires every [Einitlist_std backing t]
+    to have [t] an instance of <<std::initializer_list>> whose template argument
+    agrees with the element type of [backing]. The negative cases for that live
+    beside it, in [lang/cpp/syntax/typed.v]. *)
+
+#[local] Open Scope pstring_scope.
+
+(** Every function of interest takes no arguments, so its identifier determines
+    its name. *)
+Definition lookup (fn : PrimString.string) : option ObjValue :=
+  test_cpp.source.(symbols) !! Nglobal (Nfunction function_qualifiers.N fn []).
+
+(** The body of [fn], or [None] if it is absent or not a definition. A [None]
+    fails the [context] matches below rather than passing them, except for the
+    one inverted match, which is paired with a positive one for that reason. *)
+Definition body (fn : PrimString.string) : option Stmt :=
+  match lookup fn with
+  | Some (Ofunction f) =>
+      match f.(f_body) with
+      | Some (Impl s) => Some s
+      | _ => None
+      end
+  | _ => None
+  end.
+
+(** ** Where the [Einitlist_std] nodes are
+
+    NOTE: [lazymatch], not [match]. A [match] on a term backtracks into the next
+    branch when the selected branch's tactic fails, which turns both the
+    diagnostic [fail]s and the inverted match in [TEST_empty_list] into dead
+    code that always succeeds. *)
+
+(** <<sum({1, 2, 3})>>: an argument of class type. The backing array is a
+    temporary <<const int[3]>>, so it dies with the full-expression. *)
+Succeed Example TEST_pass_to_function : True :=
+  ltac:(let b := eval vm_compute in (body "pass_to_function") in
+        lazymatch b with
+        | context [ Einitlist_std
+                      (Ematerialize_temp (Einitlist [_;_;_] None (Tarray _ 3)) _) _ ] =>
+            exact I
+        | _ => fail 0 "no Einitlist_std over a temporary const int[3] in" b
+        end).
+
+(** <<Holder h = {1, 2, 3};>>, copy-initialization of a class with an
+    <<initializer_list>> constructor. clang produces the same node here as for
+    direct-initialization below; the two cases exist to pin that both C++ forms
+    reach [Einitlist_std]. *)
+Succeed Example TEST_copy_init_class : True :=
+  ltac:(let b := eval vm_compute in (body "copy_init_class") in
+        lazymatch b with
+        | context [ Einitlist_std
+                      (Ematerialize_temp (Einitlist [_;_;_] None (Tarray _ 3)) _) _ ] =>
+            exact I
+        | _ => fail 0 "no Einitlist_std over a temporary const int[3] in" b
+        end).
+
+(** <<Holder h{1, 2, 3};>>, direct-initialization. *)
+Succeed Example TEST_direct_init_class : True :=
+  ltac:(let b := eval vm_compute in (body "direct_init_class") in
+        lazymatch b with
+        | context [ Einitlist_std
+                      (Ematerialize_temp (Einitlist [_;_;_] None (Tarray _ 3)) _) _ ] =>
+            exact I
+        | _ => fail 0 "no Einitlist_std over a temporary const int[3] in" b
+        end).
+
+(** <<sum({1, 2, 3}) + sum({})>>: two braced-init-lists in one full-expression,
+    but only one backing array — clang default-constructs for <<{}>>. *)
+Succeed Example TEST_nested_elements : True :=
+  ltac:(let b := eval vm_compute in (body "nested_elements") in
+        lazymatch b with
+        | context [ Einitlist_std
+                      (Ematerialize_temp (Einitlist [_;_;_] None (Tarray _ 3)) _) _ ] =>
+            idtac
+        | _ => fail 0 "no Einitlist_std over a temporary const int[3] in" b
+        end;
+        lazymatch b with
+        | context [ Econstructor _ []
+                      (Tnamed (Ninst std_initializer_list [Atype Tint])) ] => exact I
+        | _ => fail 0 "no default-constructed std::initializer_list<int> in" b
+        end).
+
+(** <<return {{1, 2}, {3, 4}};>>: class elements, so each element of the backing
+    <<const Widget[2]>> is itself a braced-init-list — an [Einitlist], not a
+    nested [Einitlist_std]. *)
+Succeed Example TEST_widgets : True :=
+  ltac:(let b := eval vm_compute in (body "widgets") in
+        lazymatch b with
+        | context [ Einitlist_std
+                      (Ematerialize_temp
+                         (Einitlist [Einitlist [_;_] None _; Einitlist [_;_] None _] None
+                            (Tarray _ 2)) _) _ ] => exact I
+        | _ => fail 0 "no Einitlist_std over a temporary const Widget[2] in" b
+        end).
+
+(** <<std::initializer_list<int> l = {};>> is supported and needs no backing
+    array at all, so there is no [CXXStdInitializerListExpr] to translate. *)
+Succeed Example TEST_empty_list : True :=
+  ltac:(let b := eval vm_compute in (body "empty_list") in
+        lazymatch b with
+        | context [ Einitlist_std _ _ ] => fail 0 "unexpected Einitlist_std in" b
+        | _ => idtac
+        end;
+        lazymatch b with
+        | context [ Econstructor _ []
+                      (Tnamed (Ninst std_initializer_list [Atype Tint])) ] => exact I
+        | _ => fail 0 "no default-constructed std::initializer_list<int> in" b
+        end).
+
+(** <<std::initializer_list<int> l = {1, 2, 3};>>: the backing array is
+    lifetime-extended to match <<l>>. cpp2v still emits the [Einitlist_std]
+    node; it is the scope-extruded temporary underneath that it cannot
+    represent. *)
+Succeed Example TEST_extended_temporary : True :=
+  ltac:(let b := eval vm_compute in (body "extended_temporary") in
+        lazymatch b with
+        | context [ Einitlist_std (Eunsupported "MaterializeTemporaryExpr" _) _ ] =>
+            exact I
+        | _ => fail 0 "no Einitlist_std over a scope-extruded backing array in" b
+        end).
+
+(** ** Which of these functions BRiCk supports
+
+    Per symbol, so that the answer does not depend on what <<<initializer_list>>>
+    drags in. *)
+Definition unsupported (fn : PrimString.string) : supported.check.M :=
+  if lookup fn is Some o then supported.check.obj_value o else ["missing symbol"].
+
+Succeed Example TEST_supported :
+  List.concat
+    (List.map unsupported
+       ["pass_to_function"; "copy_init_class"; "direct_init_class";
+        "nested_elements"; "widgets"; "empty_list"]) = []
+  := ltac:(vm_compute; reflexivity).
+
+Succeed Example TEST_extended_temporary_unsupported :
+  unsupported "extended_temporary" = ["MaterializeTemporaryExpr"]
+  := ltac:(vm_compute; reflexivity).

--- a/rocq-skylabs-cpp2v/tests/std_initializer_list.t/test.v
+++ b/rocq-skylabs-cpp2v/tests/std_initializer_list.t/test.v
@@ -1,6 +1,7 @@
 Require Import skylabs.prelude.base.
 Require Import skylabs.lang.cpp.syntax.
 Require skylabs.lang.cpp.syntax.supported.
+Require Import skylabs.lang.cpp.syntax.typed.
 
 Require test.test_cpp.
 


### PR DESCRIPTION
> [!TIP]
>
> References:
> - https://eel.is/c++draft/dcl.init.list
> - https://en.cppreference.com/cpp/utility/initializer_list

Add basic support for `std::initializer_list` based on existing brace-initialization semantics.