### PR TITLE
Extend parser for names in anonymous namespaces

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/parser.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/parser.v
@@ -579,7 +579,7 @@ Module internal.
         in
         commit (keyword "operator") operator
         $ commit (op_token "~") (fun _ => Dtor <$> ident)
-        $ commit (exact "(anon)") (fun _ => mret Anonymous)
+        $ commit (exact "(anonymous namespace)") (fun _ => mret Anonymous)
         $ commit (exact "@") (fun _ => (Anon <$> decimal) <|> (FirstDecl <$> ident))
         $ commit (exact ".") (fun _ => FirstChild <$> ident) (Simple <$> ident)
       in
@@ -720,16 +720,16 @@ Module Type TESTS.
   #[local] Definition TEST_type (input : PrimString.string) (nm : type) : Prop :=
     (parse_type input) = Some nm.
 
-  Succeed Example _0 : TEST "(anon)::Msg" (Nscoped (Nglobal Nanonymous) (Nid "Msg")) := eq_refl.
+  Succeed Example _0 : TEST "(anonymous namespace)::Msg" (Nscoped (Nglobal Nanonymous) (Nid "Msg")) := eq_refl.
 
   #[local] Definition Msg : name := Nglobal $ Nid "Msg".
 
   Succeed Example _0 : TEST "Msg" Msg := eq_refl.
   Succeed Example _0 : TEST "::Msg" Msg := eq_refl.
   Succeed Example _0 : TEST "Msg::@0" (Nscoped Msg (Nanon 0)) := eq_refl.
-  Succeed Example _0 : TEST "Msg::(anon)" (Msg .:: Nanonymous) :=
+  Succeed Example _0 : TEST "Msg::(anonymous namespace)" (Msg .:: Nanonymous) :=
    eq_refl.
-  Succeed Example _0 : TEST "Msg::(anon)::id" (Nscoped (Msg .:: Nanonymous) (Nid "id")) :=
+  Succeed Example _0 : TEST "Msg::(anonymous namespace)::id" (Nscoped (Msg .:: Nanonymous) (Nid "id")) :=
    eq_refl.
   Succeed Example _0 : TEST "Msg::Msg()" (Nscoped Msg (Nctor [])) := eq_refl.
   Succeed Example _0 : TEST "Msg::~Msg()" (Nscoped Msg (Ndtor)) := eq_refl.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/parser.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/parser.v
@@ -299,6 +299,7 @@ Module internal.
       | FirstDecl (_ : PrimString.string)
       | FirstChild (_ : PrimString.string)
       | Anon (_ : N)
+      | Anonymous
       | Op (_ : OverloadableOperator)
       | OpConv (_ : type)
       | OpLit (_ : PrimString.string).
@@ -463,6 +464,7 @@ Module internal.
               | FirstDecl nm => mret $ Nfirst_decl nm
               | FirstChild nm => mret $ Nfirst_child nm
               | Anon n => mret $ Nanon n
+              | Anonymous => mret Nanonymous
               | OpConv t =>
                   (* NOTE: this is a hack because <<int()>> is parsed as a function type. *)
                   match as_conv function_qualifiers.N t with
@@ -498,6 +500,7 @@ Module internal.
          | FirstDecl n => mfail
          | FirstChild n => mfail
          | Anon _ => mfail
+         | Anonymous => mfail
          end
      end.
 
@@ -576,6 +579,7 @@ Module internal.
         in
         commit (keyword "operator") operator
         $ commit (op_token "~") (fun _ => Dtor <$> ident)
+        $ commit (exact "(anon)") (fun _ => mret Anonymous)
         $ commit (exact "@") (fun _ => (Anon <$> decimal) <|> (FirstDecl <$> ident))
         $ commit (exact ".") (fun _ => FirstChild <$> ident) (Simple <$> ident)
       in
@@ -716,11 +720,17 @@ Module Type TESTS.
   #[local] Definition TEST_type (input : PrimString.string) (nm : type) : Prop :=
     (parse_type input) = Some nm.
 
+  Succeed Example _0 : TEST "(anon)::Msg" (Nscoped (Nglobal Nanonymous) (Nid "Msg")) := eq_refl.
+
   #[local] Definition Msg : name := Nglobal $ Nid "Msg".
 
   Succeed Example _0 : TEST "Msg" Msg := eq_refl.
   Succeed Example _0 : TEST "::Msg" Msg := eq_refl.
   Succeed Example _0 : TEST "Msg::@0" (Nscoped Msg (Nanon 0)) := eq_refl.
+  Succeed Example _0 : TEST "Msg::(anon)" (Msg .:: Nanonymous) :=
+   eq_refl.
+  Succeed Example _0 : TEST "Msg::(anon)::id" (Nscoped (Msg .:: Nanonymous) (Nid "id")) :=
+   eq_refl.
   Succeed Example _0 : TEST "Msg::Msg()" (Nscoped Msg (Nctor [])) := eq_refl.
   Succeed Example _0 : TEST "Msg::~Msg()" (Nscoped Msg (Ndtor)) := eq_refl.
   Succeed Example _0 :

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
@@ -76,7 +76,7 @@ Section with_lang.
           let* args := traverse (F:=eta option) printType args in
           mret $ "operator """"" ++ i ++ parens (sepBy ", " args)
       | Nanonymous =>
-          if bool_decide (inst = "") then mret "(anon)" else None
+          if bool_decide (inst = "") then mret "(anonymous namespace)" else None
       | Nanon n => mret $ "@" ++ showN n ++ inst
       | Nfirst_decl n => mret $ "@" ++ n ++ inst
       | Nfirst_child n => mret $ "." ++ n ++ inst
@@ -292,15 +292,15 @@ Module Type TESTS.
   #[local] Definition TEST (input : PrimString.string) (nm : name) : Prop :=
     print_name nm = Some input.
 
-  Succeed Example _0 : TEST "(anon)::Msg" (Nscoped (Nglobal Nanonymous) (Nid "Msg")) := eq_refl.
+  Succeed Example _0 : TEST "(anonymous namespace)::Msg" (Nscoped (Nglobal Nanonymous) (Nid "Msg")) := eq_refl.
 
   #[local] Definition Msg : name := Nglobal $ Nid "Msg".
 
   Succeed Example _0 : TEST "Msg" Msg := eq_refl.
   Succeed Example _0 : TEST "Msg::@0" (Nscoped Msg (Nanon 0)) := eq_refl.
-  Succeed Example _0 : TEST "Msg::(anon)" (Msg .:: Nanonymous) :=
+  Succeed Example _0 : TEST "Msg::(anonymous namespace)" (Msg .:: Nanonymous) :=
    eq_refl.
-  Succeed Example _0 : TEST "Msg::(anon)::id" (Nscoped (Msg .:: Nanonymous) (Nid "id")) :=
+  Succeed Example _0 : TEST "Msg::(anonymous namespace)::id" (Nscoped (Msg .:: Nanonymous) (Nid "id")) :=
    eq_refl.
   Succeed Example _0 : TEST "Msg::Msg()" (Nscoped Msg (Nctor [])) := eq_refl.
   Succeed Example _0 : TEST "Msg::~Msg()" (Nscoped Msg Ndtor) := eq_refl.

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/name_notation/printer.v
@@ -292,10 +292,16 @@ Module Type TESTS.
   #[local] Definition TEST (input : PrimString.string) (nm : name) : Prop :=
     print_name nm = Some input.
 
+  Succeed Example _0 : TEST "(anon)::Msg" (Nscoped (Nglobal Nanonymous) (Nid "Msg")) := eq_refl.
+
   #[local] Definition Msg : name := Nglobal $ Nid "Msg".
 
   Succeed Example _0 : TEST "Msg" Msg := eq_refl.
   Succeed Example _0 : TEST "Msg::@0" (Nscoped Msg (Nanon 0)) := eq_refl.
+  Succeed Example _0 : TEST "Msg::(anon)" (Msg .:: Nanonymous) :=
+   eq_refl.
+  Succeed Example _0 : TEST "Msg::(anon)::id" (Nscoped (Msg .:: Nanonymous) (Nid "id")) :=
+   eq_refl.
   Succeed Example _0 : TEST "Msg::Msg()" (Nscoped Msg (Nctor [])) := eq_refl.
   Succeed Example _0 : TEST "Msg::~Msg()" (Nscoped Msg Ndtor) := eq_refl.
 

--- a/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/syntax/pretty.v
@@ -104,7 +104,7 @@ Section with_lang.
       | Nop_conv q t => "operator " ++ printType t ++ "()" ++ with_space (printFQ q)
       | Nop_lit i args => "operator """"_" ++ i ++ print_args args
       | Nanon n => "@" ++ showN n
-      | Nanonymous => "(anon)"
+      | Nanonymous => "(anonymous namespace)"
       | Nfirst_decl n => "#" ++ n
       | Nfirst_child n => "." ++ n
       | Nunsupported_atomic note => "?" ++ note


### PR DESCRIPTION
Also add tests to the existing printer support.

This is really minimal, but agents managed to exploit the minimal support already, so we're just making it more convenient.

Proper semantics for internal linkage remains unsupported.