### PR TITLE
Fix same_address_eq_type_ptr as suggested by Opus

### DIFF
--- a/rocq-skylabs-brick/theories/lang/cpp/logic/pred.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/pred.v
@@ -754,8 +754,9 @@ Module Type CPP_LOGIC
     Axiom same_address_eq_type_ptr : forall ty p1 p2 n,
       same_address p1 p2 ->
       size_of _ ty = Some n ->
-      (* if [ty = Tuchar], one of these pointer could provide storage for the other. *)
-      ty <> Tuchar ->
+      (* if [erase_qualifiers ty = Tuchar], one of these pointer could provide
+      storage for the other. *)
+      erase_qualifiers ty <> Tuchar ->
       (n > 0)%N ->
       type_ptr ty p1 ∧ type_ptr ty p2 ∧ live_ptr p1 ∧ live_ptr p2 ⊢
         |={↑pred_ns}=> [| p1 = p2 |].

--- a/rocq-skylabs-brick/theories/lang/cpp/model/simple_pred.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/simple_pred.v
@@ -975,8 +975,9 @@ Module SimpleCPP.
     Axiom same_address_eq_type_ptr : forall ty p1 p2 n,
       same_address p1 p2 ->
       size_of σ ty = Some n ->
-      (* if [ty = Tuchar], one of these pointer could provide storage for the other. *)
-      ty <> Tuchar ->
+      (* if [erase_qualifiers ty = Tuchar], one of these pointer could provide
+      storage for the other. *)
+      erase_qualifiers ty <> Tuchar ->
       (n > 0)%N ->
       type_ptr ty p1 ∧ type_ptr ty p2 ∧ live_ptr p1 ∧ live_ptr p2 ⊢
         |={↑pred_ns}=> [| p1 = p2 |].


### PR DESCRIPTION
The existing `ty <> Tuchar` restriction can be bypassed by using `ty = Tconst Tuchar` and `type_ptr_erase`. This PR fixes this bypass.

```
Require Import skylabs.iris.extra.proofmode.proofmode.
Require Import skylabs.lang.cpp.cpp.

Section review.
  Context `{Σ : cpp_logic} {σ : genv}.

  Lemma type_ptr_const ty p : type_ptr (Tconst ty) p -|- type_ptr ty p.
  Proof. by rewrite (type_ptr_erase (Tconst ty)) (type_ptr_erase ty). Qed.

  (* THE BYPASS: the conclusion is exactly the case [ty <> Tuchar] exists to block. *)
  Lemma same_address_eq_type_ptr_uchar p1 p2 :
    same_address p1 p2 ->
    type_ptr Tuchar p1 ∧ type_ptr Tuchar p2 ∧ live_ptr p1 ∧ live_ptr p2
    ⊢ |={↑pred_ns}=> [| p1 = p2 |].
  Proof.
    intros Hsa. rewrite -!(type_ptr_const Tuchar).
    exact /same_address_eq_type_ptr.
  Qed.
End review.
```