### PR TITLE
Disable unsound [struct_to_raw], and other fixes (WIP)

### DIFF
--- a/rocq-skylabs-brick/tests/base_offset_units.v
+++ b/rocq-skylabs-brick/tests/base_offset_units.v
@@ -1,0 +1,66 @@
+(*
+ * Copyright (c) 2026 BlueRock Security, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+
+(** Regression test: [LayoutInfo.li_offset] is an offset in *bits*, for base
+    classes as well as for fields.
+
+    cpp2v reports field offsets with [ASTRecordLayout::getFieldOffset] (bits)
+    but base-class offsets with [getBaseClassOffset], which yields
+    [CharUnits], i.e. bytes. Emitting the latter unconverted made
+    [parent_offset] compute [byteOffset / 8], collapsing every base at a byte
+    offset below 8 onto offset 0. *)
+
+Require Import skylabs.lang.cpp.parser.
+Require Import skylabs.lang.cpp.parser.plugin.cpp2v.
+Require Import skylabs.lang.cpp.semantics.
+
+cpp.prog mi prog cpp:{{
+  struct A { int a; };
+  struct B { int b; };
+  struct C : A, B { int c; };
+}}.
+
+#[local] Definition bases (tu : translation_unit) (cls : globname)
+    : option (list (classname * LayoutInfo)) :=
+  match tu.(types) !! cls with
+  | Some (Gstruct s) => Some s.(s_bases)
+  | _ => None
+  end.
+
+(** [B] follows [A], which occupies bytes [0,4): byte offset 4, bit offset 32. *)
+Example mi_base_offsets_are_bits :
+  bases mi "C"%cpp_name
+  = Some [("A"%cpp_name, {| li_offset := 0 |});
+          ("B"%cpp_name, {| li_offset := 32 |})].
+Proof. vm_compute. reflexivity. Qed.
+
+Example mi_parent_offset_is_bytes :
+  (parent_offset_tu mi "C"%cpp_name "A"%cpp_name,
+   parent_offset_tu mi "C"%cpp_name "B"%cpp_name)
+  = (Some 0%Z, Some 4%Z).
+Proof. vm_compute. reflexivity. Qed.
+
+(** The sharpest case: with the empty base optimization, distinct base
+    subobjects sit one byte apart, so a byte-valued offset would truncate to
+    zero and make the two bases indistinguishable. *)
+cpp.prog ebo prog cpp:{{
+  struct E { };
+  struct D1 : E { };
+  struct D2 : E { };
+  struct Diamond : D1, D2 { };
+}}.
+
+Example ebo_base_offsets_are_bits :
+  bases ebo "Diamond"%cpp_name
+  = Some [("D1"%cpp_name, {| li_offset := 0 |});
+          ("D2"%cpp_name, {| li_offset := 8 |})].
+Proof. vm_compute. reflexivity. Qed.
+
+Example ebo_parent_offset_distinguishes_bases :
+  (parent_offset_tu ebo "Diamond"%cpp_name "D1"%cpp_name,
+   parent_offset_tu ebo "Diamond"%cpp_name "D2"%cpp_name)
+  = (Some 0%Z, Some 1%Z).
+Proof. vm_compute. reflexivity. Qed.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/heap_pred/everywhere.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/heap_pred/everywhere.v
@@ -75,6 +75,9 @@ Section with_cpp.
       TODO: the use of [nil] in [derivationR] is justified only because it can
             be weakened, but this should probably be changed so that it tracks
             the actual initialized state.
+
+      TODO: Does not yet account correctly for layout optimizations. Its use in
+      [implicit_destruct_struct] is incompatible with [eval_o_base].
    *)
   Definition struct_defR (R : Rtype -> cQp.t -> Rep) (cls : globname) (st : Struct) (q : cQp.t) : Rep :=
     ([** list] base ∈ st.(s_bases),

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
@@ -26,7 +26,45 @@ Section with_Σ.
   (** Convert a <<struct>> to its raw representation.
    Justified by the concept of object representation.
    https://eel.is/c++draft/basic.types.general#def:representation,object
-   *)
+
+   DISABLED: this rule is unsound, because it gives a base subobject the raw
+   representation of a *complete* object of the base's type, i.e. [size_of]
+   bytes rather than the bytes the base subobject actually occupies. The
+   everyday witness is the empty base optimization:
+
+   <<
+     struct E { };                  // POD, size_of = 1, occupies 0 bytes as a base
+     struct D : E { unsigned char c; };   // standard-layout, size_of = 1, [c] at offset 0
+   >>
+
+   Applied at [E] (whose [s_layout] is [POD], so the side condition holds), the
+   rule reads [structR "E" q -|- type_ptrR ** Exists rs, rawsR q rs ** ...],
+   and [raw_bytes_of_struct_wf_size] forces [length rs = s_size E = 1]. So the
+   *empty* base subobject owns a byte -- the same byte as [D::c], which is
+   reachable through [primR_to_rawsR] and [eval_o_field] ([D] is
+   standard-layout, so that side condition holds too). Both at fraction 1
+   gives [p |-> anyR (Tnamed "D") 1$m |-- False]: the representation predicate
+   of an ordinary class is unsatisfiable, so the logic is vacuous for any
+   program containing an empty base.
+
+   Note the [s_layout ∈ [POD;Standard]] guard does not help ([E] is POD and
+   [D] is standard-layout), and neither would a per-class layout check on [E],
+   which has no members at all: the offending layout belongs to [D] while the
+   over-claiming rule is applied at [E].
+
+   The only reason this is not already exploitable is that there is no
+   [eval_o_base] (the base-class analogue of [eval_o_field]), so a base offset
+   cannot be evaluated at the interface level -- every concrete pointer model
+   does compute it ([simple_pointers_utils.o_base_off]). Adding [eval_o_base]
+   must therefore wait until this rule is fixed.
+
+   The fix is for a base subobject's extent to be the class's non-virtual
+   size (0 for an empty class) rather than [size_of], so the per-base entries
+   in [rss] cover that instead. Nothing in the workspace uses this rule today,
+   so it is commented out rather than weakened in place.
+
+   See https://github.com/SkyLabsAI/BRiCk/issues/310 for the follow-up work.
+
   Axiom struct_to_raw : forall cls st rss q,
     glob_def σ cls = Some (Gstruct st) ->
     st.(s_layout) ∈ [POD;Standard] ->
@@ -38,6 +76,7 @@ Section with_Σ.
             _field (Field cls fld.(mem_name)) |-> rawsR q rs)
     -|- type_ptrR (Tnamed cls) **
       Exists rs, rawsR q rs ** [| raw_bytes_of_struct σ cls rss rs |].
+   *)
 
   #[local] Definition implicit_destruct_ty (ty : type) :=
     anyR ty 1$m |-- |={↑pred_ns}=> tblockR ty 1$m.

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
@@ -23,48 +23,34 @@ Require Import skylabs.iris.extra.bi.linearity.
 Section with_Σ.
   Context `{Σ : cpp_logic} {σ : genv}.
 
-  (** Convert a <<struct>> to its raw representation.
-   Justified by the concept of object representation.
-   https://eel.is/c++draft/basic.types.general#def:representation,object
+  (* Convert a <<struct>> to its raw representation.
+  Justified by the concept of object representation.
+  https://eel.is/c++draft/basic.types.general#def:representation,object
 
-   DISABLED: this rule is unsound, because it gives a base subobject the raw
-   representation of a *complete* object of the base's type, i.e. [size_of]
-   bytes rather than the bytes the base subobject actually occupies. The
-   everyday witness is the empty base optimization:
+  DISABLED as unused and unsound. Take this code:
+  <<
+    struct E { };                  // POD, size_of = 1, occupies 0 bytes as a base
+    struct D : E { unsigned char c; };   // standard-layout, size_of = 1, [c] at offset 0
+  >>
+  [sizeof(E) = 1], but [E] subobjects in [D] complete objects occupy 0 bytes.
 
-   <<
-     struct E { };                  // POD, size_of = 1, occupies 0 bytes as a base
-     struct D : E { unsigned char c; };   // standard-layout, size_of = 1, [c] at offset 0
-   >>
+  We end up with both the base class and [D]'s first field claiming to own the first raw byte,
+  so, if we enable [eval_o_base] (which holds in models), we can prove
+  <<
+  structR "E" q |-- Exists r : raw_byte, rawR q r.
 
-   Applied at [E] (whose [s_layout] is [POD], so the side condition holds), the
-   rule reads [structR "E" q -|- type_ptrR ** Exists rs, rawsR q rs ** ...],
-   and [raw_bytes_of_struct_wf_size] forces [length rs = s_size E = 1]. So the
-   *empty* base subobject owns a byte -- the same byte as [D::c], which is
-   reachable through [primR_to_rawsR] and [eval_o_field] ([D] is
-   standard-layout, so that side condition holds too). Both at fraction 1
-   gives [p |-> anyR (Tnamed "D") 1$m |-- False]: the representation predicate
-   of an ordinary class is unsatisfiable, so the logic is vacuous for any
-   program containing an empty base.
+  offset_cong σ (o_base σ "D" "E") (o_field σ "D::c").
 
-   Note the [s_layout ∈ [POD;Standard]] guard does not help ([E] is POD and
-   [D] is standard-layout), and neither would a per-class layout check on [E],
-   which has no members at all: the offending layout belongs to [D] while the
-   over-claiming rule is applied at [E].
+  p ,, o_base σ "D" "E" |-> structR "E" 1$m **
+  p ,, o_field σ "D::c" |-> anyR Tbyte 1$m
+  |-- False.
 
-   The only reason this is not already exploitable is that there is no
-   [eval_o_base] (the base-class analogue of [eval_o_field]), so a base offset
-   cannot be evaluated at the interface level -- every concrete pointer model
-   does compute it ([simple_pointers_utils.o_base_off]). Adding [eval_o_base]
-   must therefore wait until this rule is fixed.
+  p |-> anyR "D" 1$m |-- False.
+  >>
 
-   The fix is for a base subobject's extent to be the class's non-virtual
-   size (0 for an empty class) rather than [size_of], so the per-base entries
-   in [rss] cover that instead. Nothing in the workspace uses this rule today,
-   so it is commented out rather than weakened in place.
-
-   See https://github.com/SkyLabsAI/BRiCk/issues/310 for the follow-up work.
-
+  See https://github.com/SkyLabsAI/BRiCk/issues/310 for the follow-up work.
+  *)
+  (*
   Axiom struct_to_raw : forall cls st rss q,
     glob_def σ cls = Some (Gstruct st) ->
     st.(s_layout) ∈ [POD;Standard] ->

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
@@ -77,7 +77,8 @@ Section with_Σ.
       now because we can not decompose [tptsto ty q Vundef] (which is what we
       get from [anyR]). *)
 
-  (** implicit destruction of an aggregate *)
+  (** implicit destruction of an aggregate.
+  XXX: Incompatible with [eval_o_base]. *)
   Axiom implicit_destruct_struct
   : forall cls st q,
       glob_def σ cls = Some (Gstruct st) ->

--- a/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/logic/layout.v
@@ -79,7 +79,7 @@ Section with_Σ.
 
   (** implicit destruction of an aggregate.
   XXX: Incompatible with [eval_o_base]. *)
-  Axiom implicit_destruct_struct
+  (* Axiom implicit_destruct_struct
   : forall cls st q,
       glob_def σ cls = Some (Gstruct st) ->
       st.(s_trivially_destructible) ->
@@ -94,7 +94,7 @@ Section with_Σ.
       un.(u_trivially_destructible) ->
       cQp.frac q = 1%Qp ->
           type_ptrR (Tnamed cls)
-      |-- (Reduce (union_defR tblockR cls un q)) -* |={↑pred_ns}=> tblockR (Tnamed cls) q.
+      |-- (Reduce (union_defR tblockR cls un q)) -* |={↑pred_ns}=> tblockR (Tnamed cls) q. *)
 
 (*
   (* the following rule would allow you to change the active entity in a union

--- a/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers.v
@@ -343,6 +343,16 @@ Module PTRS_IMPL <: PTRS_INTF.
     case: offset_of => /= [off|//]. by rewrite right_id_L.
   Qed.
 
+  Lemma eval_o_base σ (cls base : globname) st :
+    glob_def σ cls = Some (Gstruct st) ->
+    st.(s_layout) = POD \/ st.(s_layout) = Standard ->
+    eval_offset σ (o_base σ cls base) = parent_offset σ cls base.
+  Proof.
+    move => _ _.
+    rewrite /eval_offset/= /mk_offset_seg/= /eval_raw_offset /o_base_off.
+    case: parent_offset => [off|//] /=. by rewrite right_id_L.
+  Qed.
+
   Class InvolApp {X} (f : list X → list X) :=
     invol_app : ∀ xs1 xs2,
     f (xs1 ++ xs2) = f (f xs1 ++ f xs2).

--- a/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers.v
@@ -327,7 +327,7 @@ Module PTRS_IMPL <: PTRS_INTF.
     eval_offset σ (o_sub σ ty i) = Some (Z.of_N sz * i).
   Proof.
     move=> E. rewrite (comm_L _ _ i) /o_sub/eval_offset/eval_raw_offset /=.
-    rewrite /= /mkOffset /mk_offset_seg/=/o_sub_off/=.
+    rewrite /mkOffset /mk_offset_seg/=/o_sub_off/=.
     case_decide; subst; rewrite /= {}E //=.
     by rewrite right_id_L.
   Qed.
@@ -338,9 +338,9 @@ Module PTRS_IMPL <: PTRS_INTF.
     st.(s_layout) = POD \/ st.(s_layout) = Standard ->
     eval_offset σ (o_field σ f) = offset_of σ cls n.
   Proof.
-    move => -> _ _. cbn.
-    rewrite/mk_offset_seg /eval_raw_offset_seg /o_field_off /=.
-    case: offset_of => [off|//] /=. by rewrite right_id_L.
+    move => -> _ _.
+    rewrite /eval_offset/= /mk_offset_seg /eval_raw_offset /=.
+    case: offset_of => /= [off|//]. by rewrite right_id_L.
   Qed.
 
   Class InvolApp {X} (f : list X → list X) :=

--- a/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers2.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers2.v
@@ -1066,7 +1066,20 @@ Module PTRS_IMPL <: PTRS_INTF.
     s_layout st = POD \/ s_layout st = Standard ->
     eval_offset σ (o_field σ f) = offset_of σ cls n.
   Proof.
-  Admitted.
+    rewrite /eval_offset /o_field /= /o_field_off/=.
+    move=> -> _ _ /=.
+    case: offset_of => /= [off|//]. by rewrite right_id_L.
+  Qed.
+
+  Lemma eval_o_base σ (cls base : globname) st :
+    glob_def σ cls = Some (Gstruct st) ->
+    st.(s_layout) = POD \/ st.(s_layout) = Standard ->
+    eval_offset σ (o_base σ cls base) = parent_offset σ cls base.
+  Proof.
+    rewrite /eval_offset /o_base /= /o_base_off.
+    move => _ _ /=.
+    case: parent_offset => [off|//] /=. by rewrite right_id_L.
+  Qed.
 
   Lemma eval_offset_resp_norm :
     ∀ σ os,

--- a/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers2.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/inductive_pointers2.v
@@ -1047,23 +1047,20 @@ Module PTRS_IMPL <: PTRS_INTF.
   Definition eval_offset (σ : genv) (os : offset) : option Z :=
     eval_offset_aux σ (`os).
 
-  Lemma eval_o_sub' :
-    ∀ σ (ty : type) (i : Z) (sz : N),
+  Lemma eval_o_sub' σ (ty : type) (i : Z) (sz : N) :
       size_of σ ty = Some sz ->
       eval_offset σ (o_sub σ ty i) = Some (sz * i).
   Proof.
     rewrite /eval_offset /o_sub.
-    move=> σ ty i n Hsome.
+    move=> Hsome.
     case_match; subst; simpl.
-    { f_equal. lia. }
+    { by rewrite right_absorb_L. }
     {
-      rewrite /o_sub_off Hsome /=.
-      f_equal. lia.
+      by rewrite /o_sub_off Hsome /= right_id_L comm_L.
     }
   Qed.
 
-  Lemma eval_o_field :
-  ∀ σ (f : name) (n : atomic_name) (cls : name) (st : Struct),
+  Lemma eval_o_field σ f n cls st :
     f = Field cls n ->
     glob_def σ cls = Some (Gstruct st) ->
     s_layout st = POD \/ s_layout st = Standard ->

--- a/rocq-skylabs-brick/theories/lang/cpp/model/simple_pointers.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/model/simple_pointers.v
@@ -274,7 +274,13 @@ Module SIMPLE_PTRS_IMPL <: PTRS_INTF.
       glob_def σ cls = Some (Gstruct st) ->
       st.(s_layout) = POD \/ st.(s_layout) = Standard ->
       eval_offset σ (o_field σ f) = offset_of σ cls n.
-    Proof. (* done. Qed. *) Admitted. (* TODO *)
+    Proof. by move=>-> _ _. Qed.
+
+    Lemma eval_o_base (cls base : globname) st :
+      glob_def σ cls = Some (Gstruct st) ->
+      st.(s_layout) = POD \/ st.(s_layout) = Standard ->
+      eval_offset σ (o_base σ cls base) = parent_offset σ cls base.
+    Proof. by move=> _ _. Qed.
 
     (* [eval_offset] respects the monoidal structure of [offset]s _for well-defined offsets_. *)
     Lemma eval_offset_dot : ∀ (o1 o2 : offset),

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/ptrs.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/ptrs.v
@@ -317,6 +317,16 @@ Module Type PTRS.
       st.(s_layout) = POD \/ st.(s_layout) = Standard ->
       eval_offset σ (o_field σ f) = offset_of σ cls n.
 
+    (*
+    Valid in models, but currently blocked.
+    *)
+    (*
+    Axiom eval_o_base : ∀ (σ : genv) (cls base : globname) st,
+      glob_def σ cls = Some (Gstruct st) ->
+      st.(s_layout) = POD \/ st.(s_layout) = Standard ->
+      eval_offset σ (o_base σ cls base) = parent_offset σ cls base.
+    *)
+
     (* [eval_offset] respects the monoidal structure of [offset]s _for well-defined offsets_. *)
     Axiom eval_offset_dot : ∀ {o1 o2 s1 s2},
       eval_offset σ o1 = Some s1 ->

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/ptrs.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/ptrs.v
@@ -318,7 +318,11 @@ Module Type PTRS.
       eval_offset σ (o_field σ f) = offset_of σ cls n.
 
     (*
-    Valid in models, but currently blocked.
+    Valid in models, but currently incompatible with the following rules, that
+    do not model empty-base optimization correctly.
+
+    - [implicit_destruct_struct] (enabled)
+    - [struct_to_raw]/[raw_bytes_of_struct_wf_base] (disabled).
     *)
     (*
     Axiom eval_o_base : ∀ (σ : genv) (cls base : globname) st,

--- a/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
+++ b/rocq-skylabs-brick/theories/lang/cpp/semantics/values.v
@@ -321,11 +321,20 @@ Module Type RAW_BYTES_VAL
                    Some (length bytes) = N.to_nat <$> (size_of σ mty)).
    *)
 
-  (** The raw bytes in each base is the size of the base *)
+  (* The raw bytes in each base is the size of the base.
+  DISABLED because unsound against empty base optimization.
+  Incompatible with [eval_o_base].
+  <<
+    struct E { };                  // POD, size_of = 1, occupies 0 bytes as a base
+    struct D : E { unsigned char c; };   // standard-layout, size_of = 1, [c] at offset 0
+  >>
+  *)
+  (*
   Axiom raw_bytes_of_struct_wf_base : forall σ cls flds rs base bytes,
     raw_bytes_of_struct σ cls flds rs ->
     flds !! FieldOrBase.Base base = Some bytes ->
     Some (length bytes) = N.to_nat <$> (size_of σ $ Tnamed base).
+  *)
 
   (** The bytes at the offset are the ones that are referenced by the field *)
   Axiom raw_bytes_of_struct_offset : forall σ cls flds rs m bytes off,

--- a/rocq-skylabs-cpp2v/src/PrintDecl.cpp
+++ b/rocq-skylabs-cpp2v/src/PrintDecl.cpp
@@ -340,10 +340,13 @@ static fmt::Formatter &printClassName(CoqPrinter &print, QualType type,
     return printClassName(print, type.getTypePtrOrNull(), cprint, loc);
 }
 
-static fmt::Formatter &printLayoutInfo(CoqPrinter &print,
-                                       CharUnits::QuantityType li) {
+/// Print a [LayoutInfo]. Its offset is measured in *bits* (see the comment on
+/// [LayoutInfo] in [lang/cpp/syntax/decl.v]); callers must convert. Note that
+/// clang reports field offsets in bits ([getFieldOffset]) but base-class
+/// offsets in [CharUnits] ([getBaseClassOffset]).
+static fmt::Formatter &printLayoutInfo(CoqPrinter &print, uint64_t bit_offset) {
     guard::ctor _(print, "Build_LayoutInfo");
-    return print.output() << li;
+    return print.output() << bit_offset;
 }
 
 static const RecordDecl *getTypeAsRecord(const ValueDecl &decl) {
@@ -448,8 +451,9 @@ static fmt::Formatter &printStructBases(const CXXRecordDecl &decl,
         guard::ctor _(print, "mkBase");
         if (auto record = type->getAsCXXRecordDecl()) {
             cprint.printName(print, record, loc::of(type)) << fmt::nbsp;
-            auto li =
-                layout ? layout->getBaseClassOffset(record).getQuantity() : 0;
+            auto li = layout ? cprint.getContext().toBits(
+                                   layout->getBaseClassOffset(record))
+                             : 0;
             return printLayoutInfo(print, li);
         } else {
             {


### PR DESCRIPTION
`struct_to_raw` gives a base subobject the raw representation of a **complete** object of the base's type — `size_of` bytes rather than the bytes the base subobject actually occupies. This is unsound, and the everyday witness is the empty base optimization, not some exotic tail-padding corner:

```cpp
struct E { };                        // POD, size_of = 1, occupies 0 bytes as a base
struct D : E { unsigned char c; };   // standard-layout, size_of = 1, c at offset 0
```

Applied at `E` — no bases, no fields, `s_layout = POD`, so the side condition holds — the rule degenerates to

```coq
structR "E" q -|- type_ptrR (Tnamed "E") ** Exists rs, rawsR q rs ** [| raw_bytes_of_struct σ "E" ∅ rs |]
```

and `raw_bytes_of_struct_wf_size` forces `length rs = s_size E = 1`. So the *empty* base subobject owns a byte. Inside `D` that subobject sits at offset 0 — and so does `D::c`, whose byte is reachable through `primR_to_rawsR` and `eval_o_field` (`D` is standard-layout, so that side condition holds too). Two full-fraction claims on one byte give

```coq
Lemma ebo_False (p : ptr) : p |-> anyR (Tnamed "D") 1$m |-- False.
```

i.e. the representation predicate of an ordinary C++ class is unsatisfiable, and the logic is vacuous for any program containing an empty base.

This was confirmed by a machine-checked Rocq derivation (using `cpp.prog`, so the layout is clang's, not hand-written). `Print Assumptions` on it names, besides ordinary infrastructure: `struct_to_raw`, `raw_bytes_of_struct(_wf_size)`, `tptsto_ptr_congP_transport`, `eval_o_field`, and `eval_o_base`.

## Why the existing guards don't help

- The `s_layout ∈ [POD;Standard]` guard is satisfied: `E` is POD and `D` is standard-layout.
- A per-class layout-disjointness check on `E` would not help either — `E` has no members to be disjoint from. The offending layout belongs to `D`, while the over-claiming rule is applied at `E`.

## Ordering constraint on `eval_o_base`

The derivation needs one axiom that does not exist yet: `eval_o_base`, the base-class analogue of `eval_o_field` in `lang/cpp/semantics/ptrs.v`, with the same POD/Standard guard. Every concrete pointer model already computes exactly it (`simple_pointers_utils.o_base_off := parent_offset σ derived base`). So the bug is **latent in the current axiom set**: the only thing making it unreachable today is that no interface-level rule can evaluate a base offset.

Consequently `eval_o_base` must not be added until this rule is fixed — doing so first would make the axiom set outright inconsistent.

## Why comment out rather than weaken

`grep -rn "struct_to_raw" fmdeps/ bluerock/` returns no hits outside the declaration itself. With nothing to migrate, disabling it is the smallest step that removes the unsoundness, and it keeps the statement and the analysis in the tree for whoever writes the fix.

The fix, tracked by #310, is for a base subobject's extent to be the class's non-virtual size (0 for an empty class) rather than `size_of`, so the per-base entries in `rss` cover that instead.

## Validation

- `make -j8 stage1` — clean.
- `dune build @fmdeps/BRiCk/rocq-skylabs-brick/all` — clean; `layout.v` compiles with the axiom commented out.
- `dune build @vendored/install @fmdeps/all @fmdeps/runtest` — compiled the whole downstream Rocq graph (all of `rocq-skylabs-auto-cpp`, `rocq-skylabs-cpp-stdlib`, `rocq-brick-spec-strength`, `auto-docs`, `skylabs-fm/scaffold`) with **zero Rocq errors**, but did **not** finish clean on the machine used: 44 targets fail for a pre-existing environmental reason (no libstdc++ headers available to `cpp2v`; `CPP2V_DOCKER_ENABLED` unset), plus some macOS/AArch64 cram diffs (BSD `wc -l` padding, ARM `__Bfloat16x*_t` typedefs).

  This was confirmed independent of the patch by reproducing one of the failures (`fmdeps/auto/rocq-skylabs-auto-cpp/tests/destructuring/test_pair.vo`) on an unpatched checkout, and by checking that `clang++ -std=c++20 -stdlib=libstdc++ -fsyntax-only` fails standalone on a bare `#include <utility>`. CI should be the judge of a fully clean run.

Draft, pending review of the argument above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
