### PR TITLE
`Frame` instances for `observable`

### DIFF
--- a/rocq-skylabs-iris/theories/bi/observe.v
+++ b/rocq-skylabs-iris/theories/bi/observe.v
@@ -625,6 +625,15 @@ Section observable_theory.
     apply (anti_symm (⊢)); apply observable_mono, HE.
   Qed.
 
+  #[global] Instance frame_observable_observe_l p (P Q : PROP) :
+    Observe Q P ->
+    Frame p (observable P) Q emp.
+  Proof.
+    rewrite /Frame bi.intuitionistically_if_elim.
+    iIntros (HPQR) "[#O _]".
+    by iApply (observable_observe P Q with "O").
+  Qed.
+
 End observable_theory.
 
 #[global] Hint Resolve observe_intro_only_provable_simple : core.


### PR DESCRIPTION
These can potentially simplify manual IPM proofs around `observable` by a whole lot. Unfortunately, `observable` is used in such a weird way (with lots of `Observe _ (observable _))` instances that seem to be load-bearing) that it's not entirely easy to make everything work nicely. To avoid this particular rabbit hole, I am not making the changes to BHV just yet.