### PR TITLE
expose `is_projection` to both Ltac and Ltac2

### DIFF
--- a/ltac2-extra/plugin/misc.ml
+++ b/ltac2-extra/plugin/misc.ml
@@ -10,6 +10,7 @@ open Tac2ffi
 open Tac2val
 open Tac2externals
 open Rocq_extra.Extra
+open Structures
 
 let define s =
   define Tac2expr.{ mltac_plugin = "ltac2_extensions"; mltac_tactic = s }
@@ -600,6 +601,12 @@ let _ =
   define "transparent_state_inter"
     (transparent_state @-> transparent_state @-> ret transparent_state)
     TransparentState.inter
+
+(* is_projection (with primitive and non-primitive projections) *)
+let _ =
+  define "is_projection"
+    (constant @-> ret bool)
+    Structure.is_projection
 
 (* case_bt *)
 

--- a/ltac2-extra/theories/internal/constr.v
+++ b/ltac2-extra/theories/internal/constr.v
@@ -663,6 +663,11 @@ Module Constr.
     | _               => false
     end.
 
+  (** [is_proj_ext cnst] checks whether [cnst] is a projection or not. Unlike [is_proj],
+      [is_proj_ext] returns true even for non-primitive records. *)
+  Ltac2 @ external is_proj_ext : constant -> bool :=
+    "ltac2_extensions" "is_projection".
+
   (** [specialize_products ty args] instantiates the first [Array.lenght args]
       [Prod] nodes of type [ty], with the terms in [args]. Weak-head reduction
       is performed at each step, so [c] only needs to be convertible to enough

--- a/ltac2-extra/theories/internal/ltac1.v
+++ b/ltac2-extra/theories/internal/ltac1.v
@@ -7,13 +7,14 @@
 
 Require Import skylabs.ltac2.extra.internal.init.
 Require Import skylabs.ltac2.extra.internal.constr.
+Require Import skylabs.ltac2.extra.internal.control.
 Require Import skylabs.ltac2.extra.internal.string.
 Require Import skylabs.ltac2.extra.internal.option.
 
 (** Minor extensions to [Ltac2.Ltac1] *)
 Module Ltac1.
   Import Ltac2 Init.
-  Export Ltac2.Ltac1.
+  Export Ltac2.Ltac1 Constr.
 
   (** [to_string v] attempts to build a string from an Ltac1 value, intended
       to be a Coq term representing a string (from [Coq.Strings.String]). *)
@@ -32,4 +33,24 @@ Module Ltac1.
       end
     in
     Option.bind (to_constr v) to_bool_constr.
+
+  Ltac is_proj_ext x :=
+    idtac ;
+    let tac :=
+      ltac2:(ltac1_x |-
+               let x := Ltac1.to_constr ltac1_x in
+               let x :=
+                 match x with
+                 | Some x =>
+                     match Unsafe.kind x with
+                     | Unsafe.Constant c _ => c
+                     | _ =>
+                         throw_invalid! "is_proj_ext: expecting a constant name but got %t" x
+                     end
+                 | None =>
+                     throw_invalid! "is_proj_ext: expecting constr but got %s" (Ltac1.tag_name ltac1_x)
+                 end in
+               if Constr.is_proj_ext x then () else Control.zero (Tactic_failure None)) in
+    tac x.
+
 End Ltac1.


### PR DESCRIPTION
The existing functions in Ltac and Ltac2, both named `is_proj`, only return true for primitive projections. This one takes non-primitive projections into account as well